### PR TITLE
Add app group support for iOS

### DIFF
--- a/ios/QuickSQLite.mm
+++ b/ios/QuickSQLite.mm
@@ -31,9 +31,20 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
   auto &runtime = *jsiRuntime;
   auto callInvoker = bridge.jsCallInvoker;
 
-  // Get iOS app's document directory (to safely store database .sqlite3 file)
-  NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, true);
-  NSString *documentPath = [paths objectAtIndex:0];
+  // TODO: how should we configure this?
+  // NSString *appGroupID = @"group.com.myappexample";
+  NSString *documentPath; 
+
+  if (appGroupID != nil) {
+    // Get the app groups container storage url
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSURL *storeUrl = [fileManager containerURLForSecurityApplicationGroupIdentifier:appGroupID];
+    documentPath = [storeUrl path];
+  } else {
+    // Get iOS app's document directory (to safely store database .sqlite3 file)
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, true);
+    documentPath = [paths objectAtIndex:0];
+  }
 
   osp::install(runtime, callInvoker,[documentPath UTF8String]);
   return @true;

--- a/ios/QuickSQLite.mm
+++ b/ios/QuickSQLite.mm
@@ -31,8 +31,8 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
   auto &runtime = *jsiRuntime;
   auto callInvoker = bridge.jsCallInvoker;
 
-  // TODO: how should we configure this?
-  // NSString *appGroupID = @"group.com.myappexample";
+  // Get appGroupID value from Info.plist using key "AppGroup"
+  NSString *appGroupID = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"AppGroup"];
   NSString *documentPath; 
 
   if (appGroupID != nil) {
@@ -46,7 +46,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
     documentPath = [paths objectAtIndex:0];
   }
 
-  osp::install(runtime, callInvoker,[documentPath UTF8String]);
+  osp::install(runtime, callInvoker, [documentPath UTF8String]);
   return @true;
 }
 

--- a/ios/QuickSQLite.mm
+++ b/ios/QuickSQLite.mm
@@ -39,6 +39,13 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
     // Get the app groups container storage url
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSURL *storeUrl = [fileManager containerURLForSecurityApplicationGroupIdentifier:appGroupID];
+
+    if (storeUrl == nil) {
+      NSLog(@"Invalid AppGroup ID provided (%@). Check the value of \"AppGroup\" in your Info.plist file", appGroupID);
+      return @false;
+    }
+    NSLog(@"Configured with AppGroup ID: %@", appGroupID);
+
     documentPath = [storeUrl path];
   } else {
     // Get iOS app's document directory (to safely store database .sqlite3 file)


### PR DESCRIPTION
This adds app group support for iOS configurable via adding an `AppGroup` key to `Info.plist` allowing sharing data between process in the same app group (e.g. with a share extension).

This is the simplest solution but I outline some ways it could potentially be made more robust [here](https://github.com/margelo/react-native-quick-sqlite/issues/6). I'm happy to work on including anything from that outline as well should it seem useful.