### PR TITLE
Fix crash when with sqlite records that contain blobs

### DIFF
--- a/cpp/sqliteBridge.cpp
+++ b/cpp/sqliteBridge.cpp
@@ -337,7 +337,7 @@ SQLiteOPResult sqliteExecute(string const dbName, string const &query, vector<Qu
             {
               int blob_size = sqlite3_column_bytes(statement, i);
               const void *blob = sqlite3_column_blob(statement, i);
-              uint8_t *data;
+              uint8_t *data = new uint8_t[blob_size];
               memcpy(data, blob, blob_size);
               row[column_name] = createArrayBufferQuickValue(data, blob_size);
               break;


### PR DESCRIPTION
When copying blob's data from the sqlite column into the ArrayBuffer QuickValue, the code was using mempy to copy the data from the blob into a `data` pointer. 

The `data` pointer was uninitialized and did not point to any valid memory. This resulted in undefined behavior, and ultimately crashes. Xcode was displaying a warning on this particular line, which is what tipped me off to the issue here:

![Screenshot 2023-07-25 at 9 23 09 AM](https://github.com/margelo/react-native-quick-sqlite/assets/88001738/bd67e342-dbd6-49d9-ada7-aec2d44917f8)


To fix and safely copy the data, I added in an allocation for the `data` pointer of size `blob_size`.

Related issue from previous repository: https://github.com/ospfranco/react-native-quick-sqlite/issues/91

---

I tried to follow the instructions as outlined in the [contributing guidelines](https://github.com/margelo/react-native-quick-sqlite/blob/81fda8f4694adc3add39b403f601ef3f0a2a1829/CONTRIBUTING.md) to run the example app & test suite. However I'm unable to run that app locally due to compilation issues (both iOS & Android).