### PR TITLE
fix(readme): update how to specify custom build flags via CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     if target.name == "react-native-quick-sqlite" then
       target.build_configurations.each do |config|
-        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', '<SQLITE_FLAGS>']
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'SQLITE_ENABLE_FTS5=1'
       end
     end
   end


### PR DESCRIPTION
Now the library has a default `GCC_PREPROCESSOR_DEFINITIONS` flag, so `||=` operator doesn't work in your `Podfile`.
It updates to use `<<` instead.