### PR TITLE
feat: add support for v8

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -46,12 +46,6 @@ find_package(ReactAndroid REQUIRED CONFIG)
 find_package(fbjni REQUIRED CONFIG)
 find_library(LOG_LIB log)
 
-if(${USE_HERMES})
-  set(JSEXECUTOR_LIB ReactAndroid::hermes_executor)
-else()
-  set(JSEXECUTOR_LIB ReactAndroid::jscexecutor)
-endif()
-
 
 target_link_libraries(
   ${PACKAGE_NAME}
@@ -60,6 +54,5 @@ target_link_libraries(
   ReactAndroid::jsi
   ReactAndroid::turbomodulejsijni
   ReactAndroid::react_nativemodule_core
-  ${JSEXECUTOR_LIB}
   android
 )

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -86,7 +86,9 @@ android {
               "META-INF/**",
               "**/libjsi.so",
               "**/libreact_nativemodule_core.so",
-              "**/libturbomodulejsijni.so"
+              "**/libturbomodulejsijni.so",
+              "**/libc++_shared.so",
+              "**/libfbjni.so"
       ]
     }
     


### PR DESCRIPTION
We currently add JSExecutor dependency which is not really used by the library. 
That blocks react-native-v8 users from using the lib. The pr removes that dependency and at the same time unblocks v8 users. 