### PR TITLE
use cacheDir for setting TMPDIR env to solve android 12 issue

### DIFF
--- a/android/cpp-adapter.cpp
+++ b/android/cpp-adapter.cpp
@@ -24,12 +24,14 @@ private:
   static void installNativeJsi(
       jni::alias_ref<jni::JObject> thiz, jlong jsiRuntimePtr,
       jni::alias_ref<react::CallInvokerHolder::javaobject> jsCallInvokerHolder,
-      jni::alias_ref<jni::JString> docPath) {
+      jni::alias_ref<jni::JString> docPath,
+      jni::alias_ref<jni::JString> cachePath) {
     auto jsiRuntime = reinterpret_cast<jsi::Runtime *>(jsiRuntimePtr);
     auto jsCallInvoker = jsCallInvokerHolder->cthis()->getCallInvoker();
     std::string docPathString = docPath->toStdString();
+    std::string cachePathString = cachePath->toStdString();
 
-    osp::install(*jsiRuntime, jsCallInvoker, docPathString.c_str());
+    osp::install(*jsiRuntime, jsCallInvoker, docPathString.c_str(), cachePathString.c_str());
   }
 
   static void clearStateNativeJsi(jni::alias_ref<jni::JObject> thiz) {

--- a/android/src/main/java/com/reactnativequicksqlite/QuickSQLiteBridge.java
+++ b/android/src/main/java/com/reactnativequicksqlite/QuickSQLiteBridge.java
@@ -7,7 +7,7 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
 
 public class QuickSQLiteBridge {
-  private native void installNativeJsi(long jsContextNativePointer, CallInvokerHolderImpl jsCallInvokerHolder, String docPath);
+  private native void installNativeJsi(long jsContextNativePointer, CallInvokerHolderImpl jsCallInvokerHolder, String docPath, String cachePath);
   private native void clearStateNativeJsi();
   public static final QuickSQLiteBridge instance = new QuickSQLiteBridge();
 
@@ -15,11 +15,13 @@ public class QuickSQLiteBridge {
       long jsContextPointer = context.getJavaScriptContextHolder().get();
       CallInvokerHolderImpl jsCallInvokerHolder = (CallInvokerHolderImpl)context.getCatalystInstance().getJSCallInvokerHolder();
       final String path = context.getFilesDir().getAbsolutePath();
+      final String cachePath = context.getCacheDir().getAbsolutePath();
       
       installNativeJsi(
         jsContextPointer,
         jsCallInvokerHolder,
-        path
+        path,
+        cachePath
       );
   }
 

--- a/cpp/bindings.cpp
+++ b/cpp/bindings.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include "macros.h"
 #include <iostream>
+#include <stdlib.h>
 
 using namespace std;
 using namespace facebook;
@@ -21,8 +22,11 @@ void clearState() {
   sqliteCloseAll(); 
 }
 
-void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker, const char *docPath)
+void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker, const char *docPath, const char *cachePath)
 {
+  // android 12 fix
+  setenv("TMPDIR", cachePath, 1);
+
   docPathStr = std::string(docPath);
   auto pool = std::make_shared<ThreadPool>();
   invoker = jsCallInvoker;

--- a/cpp/bindings.h
+++ b/cpp/bindings.h
@@ -5,7 +5,7 @@
 using namespace facebook;
 
 namespace osp {
-void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker, const char *docPath);
+void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker, const char *docPath, const char *cachePath);
 void clearState();
 }
 

--- a/ios/QuickSQLite.mm
+++ b/ios/QuickSQLite.mm
@@ -52,8 +52,9 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, true);
     documentPath = [paths objectAtIndex:0];
   }
+  NSString *cachePath = NSTemporaryDirectory();
 
-  osp::install(runtime, callInvoker, [documentPath UTF8String]);
+  osp::install(runtime, callInvoker, [documentPath UTF8String], [cachePath UTF8String]);
   return @true;
 }
 


### PR DESCRIPTION
sqlite3.c tries to use the `TMPDIR` environment variable which resolves to `/data/user/0/<app-id>/cache` except for Android 12 devices. I'm not sure if this is a bug in android, but it leads to this error message:

`WebSQL threw an error [Error: [react-native-quick-sqlite] SQL execution error: disk I/O error`

- related sql error code 10 - io Error
- extended sql error 6410 , see https://www.sqlite.org/rescode.html#ioerr_gettemppath

sqlite cannot write the temporary file, because it cannot find a valid file path.

This pull requests overwrites the `TMPDIR` variable explicitly with the cache directory. Any other ideas or solutions are welcome.