### PR TITLE
Make quick-sqlite 2x quicker?

### DIFF
--- a/cpp/JSIHelper.h
+++ b/cpp/JSIHelper.h
@@ -110,5 +110,6 @@ QuickValue createInt64QuickValue(long long value);
 QuickValue createDoubleQuickValue(double value);
 QuickValue createArrayBufferQuickValue(uint8_t *arrayBufferValue, size_t arrayBufferSize);
 jsi::Value createSequelQueryExecutionResult(jsi::Runtime &rt, SQLiteOPResult status, vector<map<string, QuickValue>> *results, vector<QuickColumnMetadata> *metadata);
+jsi::Value createSequelQueryExecutionResult2(jsi::Runtime &rt, SQLiteOPResult status, jsi::Array &results, vector<QuickColumnMetadata> *metadata);
 
 #endif /* JSIHelper_h */

--- a/cpp/bindings.cpp
+++ b/cpp/bindings.cpp
@@ -550,7 +550,9 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker
   module.setProperty(rt, "detach", move(detach));
   module.setProperty(rt, "delete", move(remove));
   module.setProperty(rt, "execute", move(execute));
+  module.setProperty(rt, "execute2", move(execute2));
   module.setProperty(rt, "executeAsync", move(executeAsync));
+  module.setProperty(rt, "executeAsync2", move(executeAsync2));
   module.setProperty(rt, "executeBatch", move(executeBatch));
   module.setProperty(rt, "executeBatchAsync", move(executeBatchAsync));
   module.setProperty(rt, "loadFile", move(loadFile));

--- a/cpp/bindings.cpp
+++ b/cpp/bindings.cpp
@@ -206,6 +206,51 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker
     }
   });
 
+
+  auto execute2 = HOSTFN("execute2", 4)
+  {
+    const string dbName = args[0].asString(rt).utf8(rt);
+    const string query = args[1].asString(rt).utf8(rt);
+    vector<QuickValue> params;
+    bool returnArrays = false;
+    if(count > 2) {
+      const jsi::Value &originalParams = args[2];
+      jsiQueryArgumentsToSequelParam(rt, originalParams, &params);
+    }
+
+    if (count == 4) {
+      returnArrays = args[3].asBool();
+    }
+
+    vector<jsi::Object> results;
+    vector<QuickColumnMetadata> metadata;
+
+    // Converting results into a JSI Response
+    try {
+      auto status = sqliteExecute2(rt, dbName, query, &params, returnArrays, &results, &metadata);
+
+      if(status.type == SQLiteError) {
+//        throw std::runtime_error(status.errorMessage);
+        throw jsi::JSError(rt, status.errorMessage);
+//        return {};
+      }
+
+      jsi::Array ar = jsi::Array(rt, results.size());
+
+      int i = 0;
+      for (auto const& result : results) {
+        ar.setValueAtIndex(rt, i, move(result));
+        i++;
+      }
+      
+      auto jsiResult = createSequelQueryExecutionResult2(rt, status, ar, &metadata);
+
+      return jsiResult;
+    } catch(std::exception &e) {
+      throw jsi::JSError(rt, e.what());
+    }
+  });
+
   auto executeAsync = HOSTFN("executeAsync", 3)
   {
     if (count < 3)
@@ -242,6 +287,73 @@ void install(jsi::Runtime &rt, std::shared_ptr<react::CallInvoker> jsCallInvoker
             } else {
               auto errorCtr = rt.global().getPropertyAsFunction(rt, "Error");
               auto error = errorCtr.callAsConstructor(rt, jsi::String::createFromUtf8(rt, status_copy.errorMessage));
+              reject->asObject(rt).asFunction(rt).call(rt, error);
+            }
+          });
+
+        }
+        catch (std::exception &exc)
+        {
+          invoker->invokeAsync([&rt, &exc] {
+            jsi::JSError(rt, exc.what());
+          });
+        }
+      };
+
+      pool->queueWork(task);
+
+      return {};
+    }));
+
+    return promise;
+  });
+
+
+  auto executeAsync2 = HOSTFN("executeAsync2", 4)
+  {
+    if (count < 4)
+    {
+      throw jsi::JSError(rt, "[react-native-quick-sqlite][executeAsync2] Incorrect arguments for executeAsync2");
+    }
+
+    const string dbName = args[0].asString(rt).utf8(rt);
+    const string query = args[1].asString(rt).utf8(rt);
+    const jsi::Value &originalParams = args[2];
+    const bool returnArrays = args[3].asBool();
+
+    // Converting query parameters inside the javascript caller thread
+    vector<QuickValue> params;
+    jsiQueryArgumentsToSequelParam(rt, originalParams, &params);
+
+    auto promiseCtr = rt.global().getPropertyAsFunction(rt, "Promise");
+    auto promise = promiseCtr.callAsConstructor(rt, HOSTFN("executor", 2) {
+      auto resolve = std::make_shared<jsi::Value>(rt, args[0]);
+      auto reject = std::make_shared<jsi::Value>(rt, args[1]);
+
+      auto task =
+      [&rt, dbName, query, params = make_shared<vector<QuickValue>>(params), returnArrays, resolve, reject]()
+      {
+        try
+        {
+          invoker->invokeAsync([&rt, dbName, query, params, returnArrays, resolve, reject]
+                               {
+          vector<jsi::Object> results;
+          vector<QuickColumnMetadata> metadata;
+          auto status = sqliteExecute2(rt, dbName, query, params.get(), returnArrays, &results, &metadata);
+            if(status.type == SQLiteOk) {
+              jsi::Array ar = jsi::Array(rt, results.size());
+
+              int i = 0;
+              for (auto const& result : results) {
+                ar.setValueAtIndex(rt, i, move(result));
+                i++;
+              }
+
+              auto jsiResult = createSequelQueryExecutionResult2(rt, status, ar, &metadata);
+              resolve->asObject(rt).asFunction(rt).call(rt, move(jsiResult));
+            } else {
+              auto errorCtr = rt.global().getPropertyAsFunction(rt, "Error");
+              auto error = errorCtr.callAsConstructor(rt, jsi::String::createFromUtf8(rt, status.errorMessage));
               reject->asObject(rt).asFunction(rt).call(rt, error);
             }
           });

--- a/cpp/sqlbatchexecutor.h
+++ b/cpp/sqlbatchexecutor.h
@@ -1,24 +1,25 @@
 /**
  * SQL Batch execution implementation using default sqliteBridge implementation
-*/
+ */
 #include "JSIHelper.h"
 #include "sqliteBridge.h"
 
 using namespace std;
 using namespace facebook;
 
-struct QuickQueryArguments {
+struct QuickQueryArguments
+{
   string sql;
   shared_ptr<vector<QuickValue>> params;
 };
 
 /**
- * Local Helper method to translate JSI objects QuickQueryArguments datastructure 
+ * Local Helper method to translate JSI objects QuickQueryArguments datastructure
  * MUST be called in the JavaScript Thread
-*/
+ */
 void jsiBatchParametersToQuickArguments(jsi::Runtime &rt, jsi::Array const &batchParams, vector<QuickQueryArguments> *commands);
 
 /**
- * Execute a batch of commands in a exclusive transaction 
-*/
+ * Execute a batch of commands in a exclusive transaction
+ */
 SequelBatchOperationResult sqliteExecuteBatch(std::string dbName, vector<QuickQueryArguments> *commands);

--- a/cpp/sqliteBridge.h
+++ b/cpp/sqliteBridge.h
@@ -25,6 +25,8 @@ SQLiteOPResult sqliteDetachDb(string const mainDBName, string const alias);
 
 SQLiteOPResult sqliteExecute(string const dbName, string const &query, vector<QuickValue> *values, vector<map<string, QuickValue>> *result, vector<QuickColumnMetadata> *metadata);
 
+SQLiteOPResult sqliteExecute2(jsi::Runtime &rt, string const dbName, string const &query, vector<QuickValue> *values, bool const returnArrays, vector<jsi::Object> *result, vector<QuickColumnMetadata> *metadata);
+
 SequelLiteralUpdateResult sqliteExecuteLiteral(string const dbName, string const &query);
 
 void sqliteCloseAll();

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -234,7 +234,7 @@ PODS:
   - React-jsinspector (0.71.1)
   - React-logger (0.71.1):
     - glog
-  - react-native-quick-sqlite (8.0.5):
+  - react-native-quick-sqlite (8.0.6):
     - React
     - React-callinvoker
     - React-Core
@@ -469,7 +469,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 60cf272aababc5212410e4249d17cea14fc36caa
   React-jsinspector: ff56004b0c974b688a6548c156d5830ad751ae07
   React-logger: 60a0b5f8bed667ecf9e24fecca1f30d125de6d75
-  react-native-quick-sqlite: 28be360af451ddd14fac8cccf5ffcac8ae9ca28a
+  react-native-quick-sqlite: e0e23b749382a85e4b57146f753de737a6c3a9e1
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   React-perflogger: ec8eef2a8f03ecfa6361c2c5fb9197ef4a29cc85
   React-RCTActionSheet: a0c023b86cf4c862fa9c4eb0f6f91fbe878fb2de


### PR DESCRIPTION
**DISCLAIMER 1:** This is not a PR intended to be merged, use at your own risk
**DISCLAIMER 2:** I don't really know anything about C++

------

## Intro
This PR is intended to spark a discussion about improving the performance of this package. Sure it's like 5-8x faster than non-JSI packages but it's still not perfect. For background, we deal with some fairly large (for mobile anyway) data sets with up to 300000 records per table, maybe with 15-30 text/number/boolean columns on average. Selecting all these rows might take 20-30 seconds or more depending on the device. Obviously selecting 30 columns across 300k records at once is a worst case scenario but if we can improve the worst case performance, we'll probably be improving the best cases too, helping our apps feel a lot more responsive.

## Potential Performance Bottlenecks

I've identified two major bottlenecks but there could be others.

### QuickValue

Digging into the package code, I can see that there is an intermediate `QuickValue` state created for every bit of data passing from JSI to SQLite and back again. It feels like this isn't necessary, and indeed for query results I have been able to make it work without. I know @ospfranco has handed this package over but maybe he can shed some light onto the original reasons for this?

### JSI Objects

That gets us a bit more perf, but converting the SQLite results to JSI objects is still pretty slow. I had an inkling that using arrays would be more efficient here. Adding this feature in gets us a full 2x performance increase vs the current intermediate values + JSI objects.

### Other???

I think the biggest issue is likely to be that creating JSI strings is slow, but that may be outside the scope of this package to solve. But maybe there are other issues that a more knowledgable eye could spot!

## The PR

This PR is what I've essentially hacked together so far to improve the two main issues. I've duplicated the `execute` and `executeAsync` methods as `execute2` and `executeAsync2` to allow performance to be compared.

Both of these new methods can take an additional `returnArrays` boolean parameter to determine whether to return results as (false) an array of objects, and (true) an array of arrays.

What I mean by this is:
```
[
    { my_field: 'hello', my_field_2: 8 },
    { my_field: 'goodbye', my_field_2: 45 }
]
```

vs

```
[
    ['hello', 8],
    ['goodbye', 45]
]
```

All seems well but it's probably quite likely I've done bad things given I hadn't touched C++ at all before looking into this.

I guess my hope is that this can get some eyes and feedback and hopefully form a basis for an actual PR into the project that will give users of the package a nice performance boost.

## Benchmarks

Based on setting up the benchmark by inserting 200000 rows into the database, each with 30 text columns containing random 64-character strings, then running each test 3 times to ensure the results were accurate.

These specific tests were performed on a Google Pixel 6 Pro with Android 14 but I've seen similar performance gains on iOS simulator, iPhone 7 Plus, iPad 2019, Samsung Galaxy Tab A 2019.


### Selecting 5000 records

| Method | Limit | Sync (ms) | Async (ms) |
|--------|--------|--------|--------|
| Current | 5000 | 382 | 372 |
| Current | 5000 | 354 | 445 |
| Current | 5000 | 394 | 493 |
| New (Objects) | 5000 | 276 | 246 |
| New (Objects) | 5000 | 272 | 232 |
| New (Objects) | 5000 | 276 | 232 |
| New (Arrays) | 5000 | 204 | 161 |
| New (Arrays) | 5000 | 225 | 162 |
| New (Arrays) | 5000 | 204 | 184 |

### Selecting 50000 records

| Method | Limit | Sync (ms) | Async (ms) |
|--------|--------|--------|--------|
| Current | 50000 | 3094 | 3480 |
| Current | 50000 | 3239 | 3594 |
| Current | 50000 | 3259 | 3719 |
| New (Objects) | 50000 | 2319 | 2589 |
| New (Objects) | 50000 | 2470 | 2659 |
| New (Objects) | 50000 | 2384 | 2660 |
| New (Arrays) | 50000 | 1702 | 1866 |
| New (Arrays) | 50000 | 1632 | 1862 |
| New (Arrays) | 50000 | 1656 | 1868 |

### Selecting 200000 records

| Method | Limit | Sync (ms) | Async (ms) |
|--------|--------|--------|--------|
| Current | 200000 | 14108 | n/a (OOM) |
| Current | 200000 | 13747 | n/a (OOM) |
| Current | 200000 | 14229 | n/a (OOM) |
| New (Objects) | 200000 | 11918 | 13395 |
| New (Objects) | 200000 | 12685 | 13638 |
| New (Objects) | 200000 | 12780 | 14277 |
| New (Arrays) | 200000 | 6932 | 7872 |
| New (Arrays) | 200000 | 7448 | 8254 |
| New (Arrays) | 200000 | 7479 | 8443 |