### PR TITLE
fix: build on react-native 0.74

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -234,9 +234,8 @@ PODS:
   - React-jsinspector (0.71.1)
   - React-logger (0.71.1):
     - glog
-  - react-native-quick-sqlite (8.0.5):
-    - React
-    - React-callinvoker
+  - react-native-quick-sqlite (8.0.6):
+    - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - react-native-safe-area-context (4.5.0):
     - RCT-Folly
@@ -469,7 +468,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 60cf272aababc5212410e4249d17cea14fc36caa
   React-jsinspector: ff56004b0c974b688a6548c156d5830ad751ae07
   React-logger: 60a0b5f8bed667ecf9e24fecca1f30d125de6d75
-  react-native-quick-sqlite: 28be360af451ddd14fac8cccf5ffcac8ae9ca28a
+  react-native-quick-sqlite: 137564ecc340d29307214706b672c6d085186533
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   React-perflogger: ec8eef2a8f03ecfa6361c2c5fb9197ef4a29cc85
   React-RCTActionSheet: a0c023b86cf4c862fa9c4eb0f6f91fbe878fb2de

--- a/react-native-quick-sqlite.podspec
+++ b/react-native-quick-sqlite.podspec
@@ -22,9 +22,13 @@ Pod::Spec.new do |s|
   s.header_mappings_dir = "cpp"
   s.source_files = "ios/**/*.{h,hpp,m,mm}", "cpp/**/*.{h,cpp,c}"
 
-  s.dependency "React-callinvoker"
-  s.dependency "React"
-  s.dependency "React-Core"
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s)
+  else
+    s.dependency "React-callinvoker"
+    s.dependency "React"
+    s.dependency "React-Core"
+  end
 
   if ENV['QUICK_SQLITE_USE_PHONE_VERSION'] == '1' then
     s.exclude_files = "cpp/sqlite3.c", "cpp/sqlite3.h"

--- a/react-native-quick-sqlite.podspec
+++ b/react-native-quick-sqlite.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.header_mappings_dir = "cpp"
   s.source_files = "ios/**/*.{h,hpp,m,mm}", "cpp/**/*.{h,cpp,c}"
 
-  if defined?(install_modules_dependencies()) != nil
+  if defined?(install_modules_dependencies())
     install_modules_dependencies(s)
   else
     s.dependency "React-callinvoker"


### PR DESCRIPTION
Use `install_modules_dependencies` if available so we can easily support new react-native versions. In that case we were missing some folly header directories when building on RN 0.74. Using this makes sure all necessary headers are included.

Fixes #37