### PR TITLE
refactor: Correct typo in columnName variable name

### DIFF
--- a/cpp/JSIHelper.cpp
+++ b/cpp/JSIHelper.cpp
@@ -12,196 +12,198 @@ using namespace facebook;
 
 QuickValue createNullQuickValue()
 {
-  return QuickValue{
-    .dataType = NULL_VALUE};
+	return QuickValue{
+			.dataType = NULL_VALUE};
 }
 
 QuickValue createBooleanQuickValue(bool value)
 {
-  return QuickValue{
-    .dataType = BOOLEAN,
-    .booleanValue = int(value)};
+	return QuickValue{
+			.dataType = BOOLEAN,
+			.booleanValue = int(value)};
 }
 
 QuickValue createTextQuickValue(string value)
 {
-  return QuickValue{
-    .dataType = TEXT,
-    .textValue = value};
+	return QuickValue{
+			.dataType = TEXT,
+			.textValue = value};
 }
 
 QuickValue createIntegerQuickValue(int value)
 {
-  return QuickValue{
-    .dataType = INTEGER,
-    .doubleOrIntValue = static_cast<double>(value)};
+	return QuickValue{
+			.dataType = INTEGER,
+			.doubleOrIntValue = static_cast<double>(value)};
 }
 
 QuickValue createIntegerQuickValue(double value)
 {
-  return QuickValue{
-    .dataType = INTEGER,
-    .doubleOrIntValue = value};
+	return QuickValue{
+			.dataType = INTEGER,
+			.doubleOrIntValue = value};
 }
 
 QuickValue createInt64QuickValue(long long value)
 {
-  return QuickValue{
-    .dataType = INT64,
-    .int64Value = value};
+	return QuickValue{
+			.dataType = INT64,
+			.int64Value = value};
 }
 
 QuickValue createDoubleQuickValue(double value)
 {
-  return QuickValue{
-    .dataType = DOUBLE,
-    .doubleOrIntValue = value};
+	return QuickValue{
+			.dataType = DOUBLE,
+			.doubleOrIntValue = value};
 }
 
 QuickValue createArrayBufferQuickValue(uint8_t *arrayBufferValue, size_t arrayBufferSize)
 {
-  return QuickValue{
-    .dataType = ARRAY_BUFFER,
-    .arrayBufferValue = shared_ptr<uint8_t>{arrayBufferValue},
-    .arrayBufferSize = arrayBufferSize};
+	return QuickValue{
+			.dataType = ARRAY_BUFFER,
+			.arrayBufferValue = shared_ptr<uint8_t>{arrayBufferValue},
+			.arrayBufferSize = arrayBufferSize};
 }
 
 void jsiQueryArgumentsToSequelParam(jsi::Runtime &rt, jsi::Value const &params, vector<QuickValue> *target)
 {
-  if (params.isNull() || params.isUndefined())
-  {
-    return;
-  }
+	if (params.isNull() || params.isUndefined())
+	{
+		return;
+	}
 
-  jsi::Array values = params.asObject(rt).asArray(rt);
+	jsi::Array values = params.asObject(rt).asArray(rt);
 
-  for (int ii = 0; ii < values.length(rt); ii++)
-  {
+	for (int ii = 0; ii < values.length(rt); ii++)
+	{
 
-    jsi::Value value = values.getValueAtIndex(rt, ii);
-    if (value.isNull() || value.isUndefined())
-    {
-      target->push_back(createNullQuickValue());
-    }
-    else if (value.isBool())
-    {
-      target->push_back(createBooleanQuickValue(value.getBool()));
-    }
-    else if (value.isNumber())
-    {
-      double doubleVal = value.asNumber();
-      int intVal = (int)doubleVal;
-      long long longVal = (long)doubleVal;
-      if (intVal == doubleVal)
-      {
-        target->push_back(createIntegerQuickValue(intVal));
-      }
-      else if (longVal == doubleVal)
-      {
-        target->push_back(createInt64QuickValue(longVal));
-      }
-      else
-      {
-        target->push_back(createDoubleQuickValue(doubleVal));
-      }
-    }
-    else if (value.isString())
-    {
-      string strVal = value.asString(rt).utf8(rt);
-      target->push_back(createTextQuickValue(strVal));
-    }
-    else if (value.isObject())
-    {
-      auto obj = value.asObject(rt);
-      if (obj.isArrayBuffer(rt))
-      {
-        auto buf = obj.getArrayBuffer(rt);
-        target->push_back(createArrayBufferQuickValue(buf.data(rt), buf.size(rt)));
-      }
-    }
-    else
-    {
-      target->push_back(createNullQuickValue());
-    }
-  }
+		jsi::Value value = values.getValueAtIndex(rt, ii);
+		if (value.isNull() || value.isUndefined())
+		{
+			target->push_back(createNullQuickValue());
+		}
+		else if (value.isBool())
+		{
+			target->push_back(createBooleanQuickValue(value.getBool()));
+		}
+		else if (value.isNumber())
+		{
+			double doubleVal = value.asNumber();
+			int intVal = (int)doubleVal;
+			long long longVal = (long)doubleVal;
+			if (intVal == doubleVal)
+			{
+				target->push_back(createIntegerQuickValue(intVal));
+			}
+			else if (longVal == doubleVal)
+			{
+				target->push_back(createInt64QuickValue(longVal));
+			}
+			else
+			{
+				target->push_back(createDoubleQuickValue(doubleVal));
+			}
+		}
+		else if (value.isString())
+		{
+			string strVal = value.asString(rt).utf8(rt);
+			target->push_back(createTextQuickValue(strVal));
+		}
+		else if (value.isObject())
+		{
+			auto obj = value.asObject(rt);
+			if (obj.isArrayBuffer(rt))
+			{
+				auto buf = obj.getArrayBuffer(rt);
+				target->push_back(createArrayBufferQuickValue(buf.data(rt), buf.size(rt)));
+			}
+		}
+		else
+		{
+			target->push_back(createNullQuickValue());
+		}
+	}
 }
 
 jsi::Value createSequelQueryExecutionResult(jsi::Runtime &rt, SQLiteOPResult status, vector<map<string, QuickValue>> *results, vector<QuickColumnMetadata> *metadata)
 {
-  if(status.type == SQLiteError) {
-    throw std::invalid_argument(status.errorMessage);
-  }
+	if (status.type == SQLiteError)
+	{
+		throw std::invalid_argument(status.errorMessage);
+	}
 
-  jsi::Object res = jsi::Object(rt);
+	jsi::Object res = jsi::Object(rt);
 
-  res.setProperty(rt, "rowsAffected", jsi::Value(status.rowsAffected));
-  if (status.rowsAffected > 0 && status.insertId != 0)
-  {
-    res.setProperty(rt, "insertId", jsi::Value(status.insertId));
-  }
+	res.setProperty(rt, "rowsAffected", jsi::Value(status.rowsAffected));
+	if (status.rowsAffected > 0 && status.insertId != 0)
+	{
+		res.setProperty(rt, "insertId", jsi::Value(status.insertId));
+	}
 
-  // Converting row results into objects
-  size_t rowCount = results->size();
-  jsi::Object rows = jsi::Object(rt);
-  if (rowCount > 0)
-  {
-    auto array = jsi::Array(rt, rowCount);
-    for (int i = 0; i < rowCount; i++)
-    {
-      jsi::Object rowObject = jsi::Object(rt);
-      auto row = results->at(i);
-      for (auto const &entry : row)
-      {
-        std::string columnName = entry.first;
-        QuickValue value = entry.second;
-        if (value.dataType == TEXT)
-        {
-          // using value.textValue (std::string) directly allows jsi::String to use length property of std::string (allowing strings with NULLs in them like SQLite does)
-          rowObject.setProperty(rt, columnName.c_str(), jsi::String::createFromUtf8(rt, value.textValue));
-        }
-        else if (value.dataType == INTEGER)
-        {
-          rowObject.setProperty(rt, columnName.c_str(), jsi::Value(value.doubleOrIntValue));
-        }
-        else if (value.dataType == DOUBLE)
-        {
-          rowObject.setProperty(rt, columnName.c_str(), jsi::Value(value.doubleOrIntValue));
-        }
-        else if (value.dataType == ARRAY_BUFFER)
-        {
-          jsi::Function array_buffer_ctor = rt.global().getPropertyAsFunction(rt, "ArrayBuffer");
-          jsi::Object o = array_buffer_ctor.callAsConstructor(rt, (int)value.arrayBufferSize).getObject(rt);
-          jsi::ArrayBuffer buf = o.getArrayBuffer(rt);
-          // It's a shame we have to copy here: see https://github.com/facebook/hermes/pull/419 and https://github.com/facebook/hermes/issues/564.
-          memcpy(buf.data(rt), value.arrayBufferValue.get(), value.arrayBufferSize);
-          rowObject.setProperty(rt, columnName.c_str(), o);
-        }
-        else
-        {
-          rowObject.setProperty(rt, columnName.c_str(), jsi::Value(nullptr));
-        }
-      }
-      array.setValueAtIndex(rt, i, move(rowObject));
-    }
-    rows.setProperty(rt, "_array", move(array));
-    res.setProperty(rt, "rows", move(rows));
-  }
+	// Converting row results into objects
+	size_t rowCount = results->size();
+	jsi::Object rows = jsi::Object(rt);
+	if (rowCount > 0)
+	{
+		auto array = jsi::Array(rt, rowCount);
+		for (int i = 0; i < rowCount; i++)
+		{
+			jsi::Object rowObject = jsi::Object(rt);
+			auto row = results->at(i);
+			for (auto const &entry : row)
+			{
+				std::string columnName = entry.first;
+				QuickValue value = entry.second;
+				if (value.dataType == TEXT)
+				{
+					// using value.textValue (std::string) directly allows jsi::String to use length property of std::string (allowing strings with NULLs in them like SQLite does)
+					rowObject.setProperty(rt, columnName.c_str(), jsi::String::createFromUtf8(rt, value.textValue));
+				}
+				else if (value.dataType == INTEGER)
+				{
+					rowObject.setProperty(rt, columnName.c_str(), jsi::Value(value.doubleOrIntValue));
+				}
+				else if (value.dataType == DOUBLE)
+				{
+					rowObject.setProperty(rt, columnName.c_str(), jsi::Value(value.doubleOrIntValue));
+				}
+				else if (value.dataType == ARRAY_BUFFER)
+				{
+					jsi::Function array_buffer_ctor = rt.global().getPropertyAsFunction(rt, "ArrayBuffer");
+					jsi::Object o = array_buffer_ctor.callAsConstructor(rt, (int)value.arrayBufferSize).getObject(rt);
+					jsi::ArrayBuffer buf = o.getArrayBuffer(rt);
+					// It's a shame we have to copy here: see https://github.com/facebook/hermes/pull/419 and https://github.com/facebook/hermes/issues/564.
+					memcpy(buf.data(rt), value.arrayBufferValue.get(), value.arrayBufferSize);
+					rowObject.setProperty(rt, columnName.c_str(), o);
+				}
+				else
+				{
+					rowObject.setProperty(rt, columnName.c_str(), jsi::Value(nullptr));
+				}
+			}
+			array.setValueAtIndex(rt, i, move(rowObject));
+		}
+		rows.setProperty(rt, "_array", move(array));
+		res.setProperty(rt, "rows", move(rows));
+	}
 
-  if(metadata != NULL)
-  {
-    size_t column_count = metadata->size();
-    auto column_array = jsi::Array(rt, column_count);
-    for (int i = 0; i < column_count; i++) {
-      auto column = metadata->at(i);
-      jsi::Object column_object = jsi::Object(rt);
-      column_object.setProperty(rt, "columnName", jsi::String::createFromUtf8(rt, column.colunmName.c_str()));
-      column_object.setProperty(rt, "columnDeclaredType", jsi::String::createFromUtf8(rt, column.columnDeclaredType.c_str()));
-      column_object.setProperty(rt, "columnIndex", jsi::Value(column.columnIndex));
-      column_array.setValueAtIndex(rt, i, move(column_object));
-    }
-    res.setProperty(rt, "metadata", move(column_array));
-  }
-  rows.setProperty(rt, "length", jsi::Value((int)rowCount));
+	if (metadata != NULL)
+	{
+		size_t column_count = metadata->size();
+		auto column_array = jsi::Array(rt, column_count);
+		for (int i = 0; i < column_count; i++)
+		{
+			auto column = metadata->at(i);
+			jsi::Object column_object = jsi::Object(rt);
+			column_object.setProperty(rt, "columnName", jsi::String::createFromUtf8(rt, column.columnName.c_str()));
+			column_object.setProperty(rt, "columnDeclaredType", jsi::String::createFromUtf8(rt, column.columnDeclaredType.c_str()));
+			column_object.setProperty(rt, "columnIndex", jsi::Value(column.columnIndex));
+			column_array.setValueAtIndex(rt, i, move(column_object));
+		}
+		res.setProperty(rt, "metadata", move(column_array));
+	}
+	rows.setProperty(rt, "length", jsi::Value((int)rowCount));
 
-  return move(res);
+	return move(res);
 }

--- a/cpp/JSIHelper.h
+++ b/cpp/JSIHelper.h
@@ -22,13 +22,13 @@ using namespace facebook;
  */
 enum QuickDataType
 {
-  NULL_VALUE,
-  TEXT,
-  INTEGER,
-  INT64,
-  DOUBLE,
-  BOOLEAN,
-  ARRAY_BUFFER,
+	NULL_VALUE,
+	TEXT,
+	INTEGER,
+	INT64,
+	DOUBLE,
+	BOOLEAN,
+	ARRAY_BUFFER,
 };
 
 /**
@@ -36,13 +36,13 @@ enum QuickDataType
  */
 struct QuickValue
 {
-  QuickDataType dataType;
-  int booleanValue;
-  double doubleOrIntValue;
-  long long int64Value;
-  string textValue;
-  shared_ptr<uint8_t> arrayBufferValue;
-  size_t arrayBufferSize;
+	QuickDataType dataType;
+	int booleanValue;
+	double doubleOrIntValue;
+	long long int64Value;
+	string textValue;
+	shared_ptr<uint8_t> arrayBufferValue;
+	size_t arrayBufferSize;
 };
 
 /**
@@ -50,8 +50,8 @@ struct QuickValue
  */
 struct QuickColumnValue
 {
-  QuickValue value;
-  string columnName;
+	QuickValue value;
+	string columnName;
 };
 
 /**
@@ -59,31 +59,31 @@ struct QuickColumnValue
  */
 enum ResultType
 {
-  SQLiteOk,
-  SQLiteError
+	SQLiteOk,
+	SQLiteError
 };
 
 struct SQLiteOPResult
 {
-  ResultType type;
-  string errorMessage;
-  int rowsAffected;
-  double insertId;
+	ResultType type;
+	string errorMessage;
+	int rowsAffected;
+	double insertId;
 };
 
 struct SequelLiteralUpdateResult
 {
-  ResultType type;
-  string message;
-  int affectedRows;
+	ResultType type;
+	string message;
+	int affectedRows;
 };
 
 struct SequelBatchOperationResult
 {
-  ResultType type;
-  string message;
-  int affectedRows;
-  int commands;
+	ResultType type;
+	string message;
+	int affectedRows;
+	int commands;
 };
 
 /**
@@ -91,9 +91,9 @@ struct SequelBatchOperationResult
  */
 struct QuickColumnMetadata
 {
-  string colunmName;
-  int columnIndex;
-  string columnDeclaredType;
+	string columnName;
+	int columnIndex;
+	string columnDeclaredType;
 };
 
 /**

--- a/cpp/sqliteBridge.cpp
+++ b/cpp/sqliteBridge.cpp
@@ -24,8 +24,8 @@ map<string, sqlite3 *> dbMap = map<string, sqlite3 *>();
 
 bool folder_exists(const std::string &foldername)
 {
-  struct stat buffer;
-  return (stat(foldername.c_str(), &buffer) == 0);
+	struct stat buffer;
+	return (stat(foldername.c_str(), &buffer) == 0);
 }
 
 /**
@@ -36,9 +36,9 @@ bool folder_exists(const std::string &foldername)
 int _mkdir(const char *path)
 {
 #if _POSIX_C_SOURCE
-  return mkdir(path);
+	return mkdir(path);
 #else
-  return mkdir(path, 0755); // not sure if this works on mac
+	return mkdir(path, 0755); // not sure if this works on mac
 #endif
 }
 
@@ -49,437 +49,433 @@ int _mkdir(const char *path)
  */
 int mkdir(const char *path)
 {
-  string current_level = "/";
-  string level;
-  stringstream ss(path);
-  // First line is empty because it starts with /User
-  getline(ss, level, '/');
-  // split path using slash as a separator
-  while (getline(ss, level, '/'))
-  {
-    current_level += level; // append folder to the current level
-                            // create current level
-    if (!folder_exists(current_level) && _mkdir(current_level.c_str()) != 0)
-      return -1;
+	string current_level = "/";
+	string level;
+	stringstream ss(path);
+	// First line is empty because it starts with /User
+	getline(ss, level, '/');
+	// split path using slash as a separator
+	while (getline(ss, level, '/'))
+	{
+		current_level += level; // append folder to the current level
+														// create current level
+		if (!folder_exists(current_level) && _mkdir(current_level.c_str()) != 0)
+			return -1;
 
-    current_level += "/"; // don't forget to append a slash
-  }
+		current_level += "/"; // don't forget to append a slash
+	}
 
-  return 0;
+	return 0;
 }
 
 inline bool file_exists(const string &path)
 {
-  struct stat buffer;
-  return (stat(path.c_str(), &buffer) == 0);
+	struct stat buffer;
+	return (stat(path.c_str(), &buffer) == 0);
 }
 
 string get_db_path(string const dbName, string const docPath)
 {
-  mkdir(docPath.c_str());
-  return docPath + "/" + dbName;
+	mkdir(docPath.c_str());
+	return docPath + "/" + dbName;
 }
 
 SQLiteOPResult sqliteOpenDb(string const dbName, string const docPath)
 {
-  string dbPath = get_db_path(dbName, docPath);
+	string dbPath = get_db_path(dbName, docPath);
 
-  int sqlOpenFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX;
+	int sqlOpenFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX;
 
-  sqlite3 *db;
-  int exit = 0;
-  exit = sqlite3_open_v2(dbPath.c_str(), &db, sqlOpenFlags, nullptr);
+	sqlite3 *db;
+	int exit = 0;
+	exit = sqlite3_open_v2(dbPath.c_str(), &db, sqlOpenFlags, nullptr);
 
-  if (exit != SQLITE_OK)
-  {
-    return SQLiteOPResult{
-      .type = SQLiteError,
-      .errorMessage = sqlite3_errmsg(db)
-    };
-  }
-  else
-  {
-    dbMap[dbName] = db;
-  }
+	if (exit != SQLITE_OK)
+	{
+		return SQLiteOPResult{
+				.type = SQLiteError,
+				.errorMessage = sqlite3_errmsg(db)};
+	}
+	else
+	{
+		dbMap[dbName] = db;
+	}
 
-  return SQLiteOPResult{
-    .type = SQLiteOk,
-    .rowsAffected = 0
-  };
+	return SQLiteOPResult{
+			.type = SQLiteOk,
+			.rowsAffected = 0};
 }
 
 SQLiteOPResult sqliteCloseDb(string const dbName)
 {
 
-  if (dbMap.count(dbName) == 0)
-  {
-    return SQLiteOPResult{
-      .type = SQLiteError,
-      .errorMessage = dbName + " is not open",
-    };
-  }
+	if (dbMap.count(dbName) == 0)
+	{
+		return SQLiteOPResult{
+				.type = SQLiteError,
+				.errorMessage = dbName + " is not open",
+		};
+	}
 
-  sqlite3 *db = dbMap[dbName];
+	sqlite3 *db = dbMap[dbName];
 
-  sqlite3_close_v2(db);
+	sqlite3_close_v2(db);
 
-  dbMap.erase(dbName);
+	dbMap.erase(dbName);
 
-  return SQLiteOPResult{
-    .type = SQLiteOk,
-  };
+	return SQLiteOPResult{
+			.type = SQLiteOk,
+	};
 }
 
-void sqliteCloseAll() {
-  for (auto const& x : dbMap) {
-    // In certain cases, this will return SQLITE_OK, mark the database connection as an unusable "zombie",
-    // and deallocate the connection later.
-    sqlite3_close_v2(x.second);
-  }
-  dbMap.clear();
+void sqliteCloseAll()
+{
+	for (auto const &x : dbMap)
+	{
+		// In certain cases, this will return SQLITE_OK, mark the database connection as an unusable "zombie",
+		// and deallocate the connection later.
+		sqlite3_close_v2(x.second);
+	}
+	dbMap.clear();
 }
 
 SQLiteOPResult sqliteAttachDb(string const mainDBName, string const docPath, string const databaseToAttach, string const alias)
 {
-  /**
-   * There is no need to check if mainDBName is opened because sqliteExecuteLiteral will do that.
-   * */
-  string dbPath = get_db_path(databaseToAttach, docPath);
-  string statement = "ATTACH DATABASE '" + dbPath + "' AS " + alias;
-  SequelLiteralUpdateResult result = sqliteExecuteLiteral(mainDBName, statement);
-  if (result.type == SQLiteError)
-  {
-    return SQLiteOPResult{
-      .type = SQLiteError,
-      .errorMessage = mainDBName + " was unable to attach another database: " + string(result.message),
-    };
-  }
-  return SQLiteOPResult{
-    .type = SQLiteOk,
-  };
+	/**
+	 * There is no need to check if mainDBName is opened because sqliteExecuteLiteral will do that.
+	 * */
+	string dbPath = get_db_path(databaseToAttach, docPath);
+	string statement = "ATTACH DATABASE '" + dbPath + "' AS " + alias;
+	SequelLiteralUpdateResult result = sqliteExecuteLiteral(mainDBName, statement);
+	if (result.type == SQLiteError)
+	{
+		return SQLiteOPResult{
+				.type = SQLiteError,
+				.errorMessage = mainDBName + " was unable to attach another database: " + string(result.message),
+		};
+	}
+	return SQLiteOPResult{
+			.type = SQLiteOk,
+	};
 }
 
 SQLiteOPResult sqliteDetachDb(string const mainDBName, string const alias)
 {
-  /**
-   * There is no need to check if mainDBName is opened because sqliteExecuteLiteral will do that.
-   * */
-  string statement = "DETACH DATABASE " + alias;
-  SequelLiteralUpdateResult result = sqliteExecuteLiteral(mainDBName, statement);
-  if (result.type == SQLiteError)
-  {
-    return SQLiteOPResult{
-      .type = SQLiteError,
-      .errorMessage = mainDBName + "was unable to detach database: " + string(result.message),
-    };
-  }
-  return SQLiteOPResult{
-    .type = SQLiteOk,
-  };
+	/**
+	 * There is no need to check if mainDBName is opened because sqliteExecuteLiteral will do that.
+	 * */
+	string statement = "DETACH DATABASE " + alias;
+	SequelLiteralUpdateResult result = sqliteExecuteLiteral(mainDBName, statement);
+	if (result.type == SQLiteError)
+	{
+		return SQLiteOPResult{
+				.type = SQLiteError,
+				.errorMessage = mainDBName + "was unable to detach database: " + string(result.message),
+		};
+	}
+	return SQLiteOPResult{
+			.type = SQLiteOk,
+	};
 }
 
 SQLiteOPResult sqliteRemoveDb(string const dbName, string const docPath)
 {
-  if (dbMap.count(dbName) == 1)
-  {
-    SQLiteOPResult closeResult = sqliteCloseDb(dbName);
-    if (closeResult.type == SQLiteError)
-    {
-      return closeResult;
-    }
-  }
+	if (dbMap.count(dbName) == 1)
+	{
+		SQLiteOPResult closeResult = sqliteCloseDb(dbName);
+		if (closeResult.type == SQLiteError)
+		{
+			return closeResult;
+		}
+	}
 
-  string dbPath = get_db_path(dbName, docPath);
+	string dbPath = get_db_path(dbName, docPath);
 
-  if (!file_exists(dbPath))
-  {
-    return SQLiteOPResult{
-      .type = SQLiteOk,
-      .errorMessage = "[react-native-quick-sqlite]: Database file not found" + dbPath
-    };
-  }
+	if (!file_exists(dbPath))
+	{
+		return SQLiteOPResult{
+				.type = SQLiteOk,
+				.errorMessage = "[react-native-quick-sqlite]: Database file not found" + dbPath};
+	}
 
-  remove(dbPath.c_str());
+	remove(dbPath.c_str());
 
-  return SQLiteOPResult{
-    .type = SQLiteOk,
-  };
+	return SQLiteOPResult{
+			.type = SQLiteOk,
+	};
 }
 
 void bindStatement(sqlite3_stmt *statement, vector<QuickValue> *values)
 {
-  size_t size = values->size();
-  if (size <= 0)
-  {
-    return;
-  }
+	size_t size = values->size();
+	if (size <= 0)
+	{
+		return;
+	}
 
-  for (int ii = 0; ii < size; ii++)
-  {
-    int sqIndex = ii + 1;
-    QuickValue value = values->at(ii);
-    QuickDataType dataType = value.dataType;
-    if (dataType == NULL_VALUE)
-    {
-      sqlite3_bind_null(statement, sqIndex);
-    }
-    else if (dataType == BOOLEAN)
-    {
-      sqlite3_bind_int(statement, sqIndex, value.booleanValue);
-    }
-    else if (dataType == INTEGER)
-    {
-      sqlite3_bind_int(statement, sqIndex, (int)value.doubleOrIntValue);
-    }
-    else if (dataType == DOUBLE)
-    {
-      sqlite3_bind_double(statement, sqIndex, value.doubleOrIntValue);
-    }
-    else if (dataType == INT64)
-    {
-      sqlite3_bind_int64(statement, sqIndex, value.int64Value);
-    }
-    else if (dataType == TEXT)
-    {
-      sqlite3_bind_text(statement, sqIndex, value.textValue.c_str(), value.textValue.length(), SQLITE_TRANSIENT);
-    }
-    else if (dataType == ARRAY_BUFFER)
-    {
-      sqlite3_bind_blob(statement, sqIndex, value.arrayBufferValue.get(), value.arrayBufferSize, SQLITE_STATIC);
-    }
-  }
+	for (int ii = 0; ii < size; ii++)
+	{
+		int sqIndex = ii + 1;
+		QuickValue value = values->at(ii);
+		QuickDataType dataType = value.dataType;
+		if (dataType == NULL_VALUE)
+		{
+			sqlite3_bind_null(statement, sqIndex);
+		}
+		else if (dataType == BOOLEAN)
+		{
+			sqlite3_bind_int(statement, sqIndex, value.booleanValue);
+		}
+		else if (dataType == INTEGER)
+		{
+			sqlite3_bind_int(statement, sqIndex, (int)value.doubleOrIntValue);
+		}
+		else if (dataType == DOUBLE)
+		{
+			sqlite3_bind_double(statement, sqIndex, value.doubleOrIntValue);
+		}
+		else if (dataType == INT64)
+		{
+			sqlite3_bind_int64(statement, sqIndex, value.int64Value);
+		}
+		else if (dataType == TEXT)
+		{
+			sqlite3_bind_text(statement, sqIndex, value.textValue.c_str(), value.textValue.length(), SQLITE_TRANSIENT);
+		}
+		else if (dataType == ARRAY_BUFFER)
+		{
+			sqlite3_bind_blob(statement, sqIndex, value.arrayBufferValue.get(), value.arrayBufferSize, SQLITE_STATIC);
+		}
+	}
 }
 
 SQLiteOPResult sqliteExecute(string const dbName, string const &query, vector<QuickValue> *params, vector<map<string, QuickValue>> *results, vector<QuickColumnMetadata> *metadata)
 {
 
-  if (dbMap.count(dbName) == 0)
-  {
-    return SQLiteOPResult{
-      .type = SQLiteError,
-      .errorMessage = "[react-native-quick-sqlite]: Database " + dbName + " is not open",
-      .rowsAffected = 0
-    };
-  }
+	if (dbMap.count(dbName) == 0)
+	{
+		return SQLiteOPResult{
+				.type = SQLiteError,
+				.errorMessage = "[react-native-quick-sqlite]: Database " + dbName + " is not open",
+				.rowsAffected = 0};
+	}
 
-  sqlite3 *db = dbMap[dbName];
+	sqlite3 *db = dbMap[dbName];
 
-  sqlite3_stmt *statement;
+	sqlite3_stmt *statement;
 
-  int statementStatus = sqlite3_prepare_v2(db, query.c_str(), -1, &statement, NULL);
+	int statementStatus = sqlite3_prepare_v2(db, query.c_str(), -1, &statement, NULL);
 
-  if (statementStatus == SQLITE_OK) // statemnet is correct, bind the passed parameters
-  {
-    bindStatement(statement, params);
-  }
-  else
-  {
-    const char *message = sqlite3_errmsg(db);
-    return SQLiteOPResult{
-      .type = SQLiteError,
-      .errorMessage = "[react-native-quick-sqlite] SQL execution error: " + string(message),
-      .rowsAffected = 0};
-  }
+	if (statementStatus == SQLITE_OK) // statemnet is correct, bind the passed parameters
+	{
+		bindStatement(statement, params);
+	}
+	else
+	{
+		const char *message = sqlite3_errmsg(db);
+		return SQLiteOPResult{
+				.type = SQLiteError,
+				.errorMessage = "[react-native-quick-sqlite] SQL execution error: " + string(message),
+				.rowsAffected = 0};
+	}
 
-  bool isConsuming = true;
-  bool isFailed = false;
+	bool isConsuming = true;
+	bool isFailed = false;
 
-  int result, i, count, column_type;
-  string column_name, column_declared_type;
-  map<string, QuickValue> row;
+	int result, i, count, column_type;
+	string column_name, column_declared_type;
+	map<string, QuickValue> row;
 
-  while (isConsuming)
-  {
-    result = sqlite3_step(statement);
+	while (isConsuming)
+	{
+		result = sqlite3_step(statement);
 
-    switch (result)
-    {
-      case SQLITE_ROW:
-        if(results == NULL)
-        {
-          break;
-        }
+		switch (result)
+		{
+		case SQLITE_ROW:
+			if (results == NULL)
+			{
+				break;
+			}
 
-        i = 0;
-        row = map<string, QuickValue>();
-        count = sqlite3_column_count(statement);
+			i = 0;
+			row = map<string, QuickValue>();
+			count = sqlite3_column_count(statement);
 
-        while (i < count)
-        {
-          column_type = sqlite3_column_type(statement, i);
-          column_name = sqlite3_column_name(statement, i);
+			while (i < count)
+			{
+				column_type = sqlite3_column_type(statement, i);
+				column_name = sqlite3_column_name(statement, i);
 
-          switch (column_type)
-          {
+				switch (column_type)
+				{
 
-            case SQLITE_INTEGER:
-            {
-              /**
-               * It's not possible to send a int64_t in a jsi::Value because JS cannot represent the whole number range.
-               * Instead, we're sending a double, which can represent all integers up to 53 bits long, which is more
-               * than what was there before (a 32-bit int).
-               *
-               * See https://github.com/margelo/react-native-quick-sqlite/issues/16 for more context.
-               */
-              double column_value = sqlite3_column_double(statement, i);
-              row[column_name] = createIntegerQuickValue(column_value);
-              break;
-            }
+				case SQLITE_INTEGER:
+				{
+					/**
+					 * It's not possible to send a int64_t in a jsi::Value because JS cannot represent the whole number range.
+					 * Instead, we're sending a double, which can represent all integers up to 53 bits long, which is more
+					 * than what was there before (a 32-bit int).
+					 *
+					 * See https://github.com/margelo/react-native-quick-sqlite/issues/16 for more context.
+					 */
+					double column_value = sqlite3_column_double(statement, i);
+					row[column_name] = createIntegerQuickValue(column_value);
+					break;
+				}
 
-            case SQLITE_FLOAT:
-            {
-              double column_value = sqlite3_column_double(statement, i);
-              row[column_name] = createDoubleQuickValue(column_value);
-              break;
-            }
+				case SQLITE_FLOAT:
+				{
+					double column_value = sqlite3_column_double(statement, i);
+					row[column_name] = createDoubleQuickValue(column_value);
+					break;
+				}
 
-            case SQLITE_TEXT:
-            {
-              const char *column_value = reinterpret_cast<const char *>(sqlite3_column_text(statement, i));
-              int byteLen = sqlite3_column_bytes(statement, i);
-              // Specify length too; in case string contains NULL in the middle (which SQLite supports!)
-              row[column_name] = createTextQuickValue(string(column_value, byteLen));
-              break;
-            }
+				case SQLITE_TEXT:
+				{
+					const char *column_value = reinterpret_cast<const char *>(sqlite3_column_text(statement, i));
+					int byteLen = sqlite3_column_bytes(statement, i);
+					// Specify length too; in case string contains NULL in the middle (which SQLite supports!)
+					row[column_name] = createTextQuickValue(string(column_value, byteLen));
+					break;
+				}
 
-            case SQLITE_BLOB:
-            {
-              int blob_size = sqlite3_column_bytes(statement, i);
-              const void *blob = sqlite3_column_blob(statement, i);
-              uint8_t *data = new uint8_t[blob_size];
-              memcpy(data, blob, blob_size);
-              row[column_name] = createArrayBufferQuickValue(data, blob_size);
-              break;
-            }
+				case SQLITE_BLOB:
+				{
+					int blob_size = sqlite3_column_bytes(statement, i);
+					const void *blob = sqlite3_column_blob(statement, i);
+					uint8_t *data = new uint8_t[blob_size];
+					memcpy(data, blob, blob_size);
+					row[column_name] = createArrayBufferQuickValue(data, blob_size);
+					break;
+				}
 
-            case SQLITE_NULL:
-              // Intentionally left blank to switch to default case
-            default:
-              row[column_name] = createNullQuickValue();
-              break;
-          }
-          i++;
-        }
-        results->push_back(move(row));
-        break;
-      case SQLITE_DONE:
-        if(metadata != NULL)
-        {
-          i = 0;
-          count = sqlite3_column_count(statement);
-          while (i < count)
-          {
-            column_name = sqlite3_column_name(statement, i);
-            const char *tp = sqlite3_column_decltype(statement, i);
-            column_declared_type = tp != NULL ? tp : "UNKNOWN";
-            QuickColumnMetadata meta = {
-              .colunmName = column_name,
-              .columnIndex = i,
-              .columnDeclaredType = column_declared_type,
-            };
-            metadata->push_back(meta);
-            i++;
-          }
-        }
-        isConsuming = false;
-        break;
+				case SQLITE_NULL:
+					// Intentionally left blank to switch to default case
+				default:
+					row[column_name] = createNullQuickValue();
+					break;
+				}
+				i++;
+			}
+			results->push_back(move(row));
+			break;
+		case SQLITE_DONE:
+			if (metadata != NULL)
+			{
+				i = 0;
+				count = sqlite3_column_count(statement);
+				while (i < count)
+				{
+					column_name = sqlite3_column_name(statement, i);
+					const char *tp = sqlite3_column_decltype(statement, i);
+					column_declared_type = tp != NULL ? tp : "UNKNOWN";
+					QuickColumnMetadata meta = {
+							.columnName = column_name,
+							.columnIndex = i,
+							.columnDeclaredType = column_declared_type,
+					};
+					metadata->push_back(meta);
+					i++;
+				}
+			}
+			isConsuming = false;
+			break;
 
-      default:
-        isFailed = true;
-        isConsuming = false;
-    }
-  }
+		default:
+			isFailed = true;
+			isConsuming = false;
+		}
+	}
 
-  sqlite3_finalize(statement);
+	sqlite3_finalize(statement);
 
-  if (isFailed)
-  {
-    const char *message = sqlite3_errmsg(db);
-    return SQLiteOPResult{
-      .type = SQLiteError,
-      .errorMessage = "[react-native-quick-sqlite] SQL execution error: " + string(message),
-      .rowsAffected = 0,
-      .insertId = 0
-    };
-  }
+	if (isFailed)
+	{
+		const char *message = sqlite3_errmsg(db);
+		return SQLiteOPResult{
+				.type = SQLiteError,
+				.errorMessage = "[react-native-quick-sqlite] SQL execution error: " + string(message),
+				.rowsAffected = 0,
+				.insertId = 0};
+	}
 
-  int changedRowCount = sqlite3_changes(db);
-  long long latestInsertRowId = sqlite3_last_insert_rowid(db);
-  return SQLiteOPResult{
-    .type = SQLiteOk,
-    .rowsAffected = changedRowCount,
-    .insertId = static_cast<double>(latestInsertRowId)};
+	int changedRowCount = sqlite3_changes(db);
+	long long latestInsertRowId = sqlite3_last_insert_rowid(db);
+	return SQLiteOPResult{
+			.type = SQLiteOk,
+			.rowsAffected = changedRowCount,
+			.insertId = static_cast<double>(latestInsertRowId)};
 }
 
 SequelLiteralUpdateResult sqliteExecuteLiteral(string const dbName, string const &query)
 {
-  // Check if db connection is opened
-  if (dbMap.count(dbName) == 0)
-  {
-    return {
-      SQLiteError,
-      "[react-native-quick-sqlite] Database not opened: " + dbName,
-      0
-    };
-  }
+	// Check if db connection is opened
+	if (dbMap.count(dbName) == 0)
+	{
+		return {
+				SQLiteError,
+				"[react-native-quick-sqlite] Database not opened: " + dbName,
+				0};
+	}
 
-  sqlite3 *db = dbMap[dbName];
+	sqlite3 *db = dbMap[dbName];
 
-  // SQLite statements need to be compiled before executed
-  sqlite3_stmt *statement;
+	// SQLite statements need to be compiled before executed
+	sqlite3_stmt *statement;
 
-  // Compile and move result into statement memory spot
-  int statementStatus = sqlite3_prepare_v2(db, query.c_str(), -1, &statement, NULL);
+	// Compile and move result into statement memory spot
+	int statementStatus = sqlite3_prepare_v2(db, query.c_str(), -1, &statement, NULL);
 
-  if (statementStatus != SQLITE_OK) // statemnet is correct, bind the passed parameters
-  {
-    const char *message = sqlite3_errmsg(db);
-    return {
-      SQLiteError,
-      "[react-native-quick-sqlite] SQL execution error: " + string(message),
-      0};
-  }
+	if (statementStatus != SQLITE_OK) // statemnet is correct, bind the passed parameters
+	{
+		const char *message = sqlite3_errmsg(db);
+		return {
+				SQLiteError,
+				"[react-native-quick-sqlite] SQL execution error: " + string(message),
+				0};
+	}
 
-  bool isConsuming = true;
-  bool isFailed = false;
+	bool isConsuming = true;
+	bool isFailed = false;
 
-  int result, i, count, column_type;
-  string column_name;
+	int result, i, count, column_type;
+	string column_name;
 
-  while (isConsuming)
-  {
-    result = sqlite3_step(statement);
+	while (isConsuming)
+	{
+		result = sqlite3_step(statement);
 
-    switch (result)
-    {
-      case SQLITE_ROW:
-        isConsuming = true;
-        break;
+		switch (result)
+		{
+		case SQLITE_ROW:
+			isConsuming = true;
+			break;
 
-      case SQLITE_DONE:
-        isConsuming = false;
-        break;
+		case SQLITE_DONE:
+			isConsuming = false;
+			break;
 
-      default:
-        isFailed = true;
-        isConsuming = false;
-    }
-  }
+		default:
+			isFailed = true;
+			isConsuming = false;
+		}
+	}
 
-  sqlite3_finalize(statement);
+	sqlite3_finalize(statement);
 
-  if (isFailed)
-  {
-    const char *message = sqlite3_errmsg(db);
-    return {
-      SQLiteError,
-      "[react-native-quick-sqlite] SQL execution error: " + string(message),
-      0};
-  }
+	if (isFailed)
+	{
+		const char *message = sqlite3_errmsg(db);
+		return {
+				SQLiteError,
+				"[react-native-quick-sqlite] SQL execution error: " + string(message),
+				0};
+	}
 
-  int changedRowCount = sqlite3_changes(db);
-  return {
-    SQLiteOk,
-    "",
-    changedRowCount};
+	int changedRowCount = sqlite3_changes(db);
+	return {
+			SQLiteOk,
+			"",
+			changedRowCount};
 }


### PR DESCRIPTION
While analyzing the code, I found a typo. There is no problem with the operation, but the contents will be delivered separately.

### Changes
1. `colunmName` -> `columnName`
