### PR TITLE
refactor: Correct typo in columnName variable name

### DIFF
--- a/cpp/JSIHelper.cpp
+++ b/cpp/JSIHelper.cpp
@@ -194,7 +194,7 @@ jsi::Value createSequelQueryExecutionResult(jsi::Runtime &rt, SQLiteOPResult sta
     for (int i = 0; i < column_count; i++) {
       auto column = metadata->at(i);
       jsi::Object column_object = jsi::Object(rt);
-      column_object.setProperty(rt, "columnName", jsi::String::createFromUtf8(rt, column.colunmName.c_str()));
+      column_object.setProperty(rt, "columnName", jsi::String::createFromUtf8(rt, column.columnName.c_str()));
       column_object.setProperty(rt, "columnDeclaredType", jsi::String::createFromUtf8(rt, column.columnDeclaredType.c_str()));
       column_object.setProperty(rt, "columnIndex", jsi::Value(column.columnIndex));
       column_array.setValueAtIndex(rt, i, move(column_object));

--- a/cpp/JSIHelper.h
+++ b/cpp/JSIHelper.h
@@ -91,7 +91,7 @@ struct SequelBatchOperationResult
  */
 struct QuickColumnMetadata
 {
-  string colunmName;
+  string columnName;
   int columnIndex;
   string columnDeclaredType;
 };

--- a/cpp/sqliteBridge.cpp
+++ b/cpp/sqliteBridge.cpp
@@ -373,7 +373,7 @@ SQLiteOPResult sqliteExecute(string const dbName, string const &query, vector<Qu
             const char *tp = sqlite3_column_decltype(statement, i);
             column_declared_type = tp != NULL ? tp : "UNKNOWN";
             QuickColumnMetadata meta = {
-              .colunmName = column_name,
+              .columnName = column_name,
               .columnIndex = i,
               .columnDeclaredType = column_declared_type,
             };


### PR DESCRIPTION
While analyzing the code, I found a typo. There is no problem with the operation, but the contents will be delivered separately.

### Changes
1. `colunmName` -> `columnName`
