### PR TITLE
Remove wrong `abiFilters` to make the lib compile when building for select ABI

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -71,7 +71,6 @@ android {
     externalNativeBuild {
         cmake {
             cppFlags "-O2", "-fexceptions", "-frtti", "-std=c++1y", "-DONANDROID"
-            abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
             arguments '-DANDROID_STL=c++_shared',
               "-DSQLITE_FLAGS='${SQLITE_FLAGS ? SQLITE_FLAGS : ''}'",
               "-DUSE_HERMES=${USE_HERMES}"


### PR DESCRIPTION
When building React Native from source for select ABIs, this library will fail on the linking step due to the relevant `.so` files from the core not existing for the ABIs that were not built. You should be able to reproduce it using `./gradlew assembleDebug --no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a`

<details>
<summary>Here's an example log</summary>

```
> Task :react-native-quick-sqlite:buildCMakeDebug[armeabi-v7a] FAILED
C/C++: ninja: Entering directory `/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/android/.cxx/Debug/lc2y1k3u/armeabi-v7a'
C/C++: : && /Users/jakubpiasecki/Library/Android/sdk/ndk/25.1.8937393/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=armv7-none-linux-androideabi21 --sysroot=/Users/jakubpiasecki/Library/Android/sdk/ndk/25.1.8937393/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -fPIC -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -march=armv7-a -mthumb -Wformat -Werror=format-security  -O2 -fexceptions -frtti -std=c++1y -DONANDROID -fno-limit-debug-info  -Wl,--build-id=sha1 -Wl,--no-rosegment -Wl,--fatal-warnings -Wl,--gc-sections -Wl,--no-undefined -Qunused-arguments -shared -Wl,-soname,libreact-native-quick-sqlite.so -o ../../../../build/intermediates/cxx/Debug/lc2y1k3u/obj/armeabi-v7a/libreact-native-quick-sqlite.so CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/sqliteBridge.cpp.o CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/sqlite3.c.o CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/JSIHelper.cpp.o CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/ThreadPool.cpp.o CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/sqlfileloader.cpp.o CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/sqlbatchexecutor.cpp.o CMakeFiles/react-native-quick-sqlite.dir/cpp-adapter.cpp.o  /Users/jakubpiasecki/Library/Android/sdk/ndk/25.1.8937393/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/lib/arm-linux-androideabi/21/liblog.so  /Users/jakubpiasecki/.gradle/caches/transforms-3/86e33899c2a40ce05499c0455d06d303/transformed/jetified-fbjni-0.5.1/prefab/modules/fbjni/libs/android.armeabi-v7a/libfbjni.so  -landroid  -latomic -lm && :
C/C++: ld: error: undefined symbol: facebook::jsi::Value::~Value()
C/C++: >>> referenced by jsi-inl.h:122 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native/ReactAndroid/build/prefab-headers/jsi/jsi/jsi-inl.h:122)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(void facebook::jsi::Object::setProperty<facebook::jsi::Function>(facebook::jsi::Runtime&, char const*, facebook::jsi::Function&&) const)
C/C++: >>> referenced by jsi-inl.h:122 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native/ReactAndroid/build/prefab-headers/jsi/jsi/jsi-inl.h:122)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(void facebook::jsi::Object::setProperty<facebook::jsi::Function>(facebook::jsi::Runtime&, char const*, facebook::jsi::Function&&) const)
C/C++: >>> referenced by jsi-inl.h:122 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native/ReactAndroid/build/prefab-headers/jsi/jsi/jsi-inl.h:122)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(void facebook::jsi::Object::setProperty<facebook::jsi::Object>(facebook::jsi::Runtime&, char const*, facebook::jsi::Object&&) const)
C/C++: >>> referenced 82 more times
C/C++: ld: error: undefined symbol: facebook::jsi::Value::~Value()
C/C++: >>> referenced by jsi.h:1145 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native/ReactAndroid/build/prefab-headers/jsi/jsi/jsi.h:1145)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(void facebook::jsi::Object::setProperty<facebook::jsi::Function>(facebook::jsi::Runtime&, char const*, facebook::jsi::Function&&) const)
C/C++: >>> referenced by jsi.h:1145 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native/ReactAndroid/build/prefab-headers/jsi/jsi/jsi.h:1145)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(void facebook::jsi::Object::setProperty<facebook::jsi::Object>(facebook::jsi::Runtime&, char const*, facebook::jsi::Object&&) const)
C/C++: >>> referenced by jsi.h:1145 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native/ReactAndroid/build/prefab-headers/jsi/jsi/jsi.h:1145)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced 10 more times
C/C++: ld: error: undefined symbol: facebook::jsi::Value::asString(facebook::jsi::Runtime&) const &
C/C++: >>> referenced by bindings.cpp:37 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:37)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_0, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_0>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced by bindings.cpp:46 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:46)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_0, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_0>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced by bindings.cpp:77 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:77)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_1, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_1>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced 19 more times
C/C++: ld: error: undefined symbol: typeinfo for facebook::jsi::JSError
C/C++: >>> referenced by jsi.h:0 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native/ReactAndroid/build/prefab-headers/jsi/jsi/jsi.h:0)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_0, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_0>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced by jsi.h:0 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native/ReactAndroid/build/prefab-headers/jsi/jsi/jsi.h:0)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_0, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_0>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced by jsi.h:0 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native/ReactAndroid/build/prefab-headers/jsi/jsi/jsi.h:0)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_0, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_0>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced 21 more times
C/C++: ld: error: undefined symbol: facebook::jsi::JSError::~JSError()
C/C++: >>> referenced by jsi.h:0 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native/ReactAndroid/build/prefab-headers/jsi/jsi/jsi.h:0)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_0, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_0>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced by jsi.h:0 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native/ReactAndroid/build/prefab-headers/jsi/jsi/jsi.h:0)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_0, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_0>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced by jsi.h:0 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native/ReactAndroid/build/prefab-headers/jsi/jsi/jsi.h:0)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_0, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_0>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced 22 more times
C/C++: ld: error: undefined symbol: facebook::jsi::JSError::JSError(facebook::jsi::Runtime&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >)
C/C++: >>> referenced by jsi.h:1460 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native/ReactAndroid/build/prefab-headers/jsi/jsi/jsi.h:1460)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(facebook::jsi::JSError::JSError(facebook::jsi::Runtime&, char const*))
C/C++: ld: error: undefined symbol: facebook::jsi::JSError::JSError(facebook::jsi::Runtime&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >)
C/C++: >>> referenced by bindings.cpp:194 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:194)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_5, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_5>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced by bindings.cpp:290 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:290)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_7, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_7>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced by bindings.cpp:337 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:337)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_8::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'(), std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_8::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'()>, void ()>::operator()())
C/C++: >>> referenced 1 more times
C/C++: ld: error: undefined symbol: facebook::jsi::Object::getPropertyAsFunction(facebook::jsi::Runtime&, char const*) const
C/C++: >>> referenced by bindings.cpp:220 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:220)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced by bindings.cpp:239 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:239)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'(), std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'()>, void ()>::operator()())
C/C++: >>> referenced by bindings.cpp:316 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:316)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_8, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_8>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced 2 more times
C/C++: ld: error: undefined symbol: facebook::jsi::Value::Value(facebook::jsi::Runtime&, facebook::jsi::Value const&)
C/C++: >>> referenced by memory:2278 (/Users/jakubpiasecki/Library/Android/sdk/ndk/25.1.8937393/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/c++/v1/memory:2278)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int), std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced by memory:2278 (/Users/jakubpiasecki/Library/Android/sdk/ndk/25.1.8937393/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/c++/v1/memory:2278)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int), std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced by jsi-inl.h:43 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native/ReactAndroid/build/prefab-headers/jsi/jsi/jsi-inl.h:43)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'(), std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'()>, void ()>::operator()())
C/C++: >>> referenced 4 more times
C/C++: ld: error: undefined symbol: facebook::jsi::Value::asObject(facebook::jsi::Runtime&) const &
C/C++: >>> referenced by bindings.cpp:241 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:241)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'(), std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'()>, void ()>::operator()())
C/C++: >>> referenced by bindings.cpp:237 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:237)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'(), std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'()>, void ()>::operator()())
C/C++: >>> referenced by bindings.cpp:277 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:277)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_7, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_7>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced 9 more times
C/C++: ld: error: undefined symbol: facebook::jsi::Object::asFunction(facebook::jsi::Runtime&) &&
C/C++: >>> referenced by bindings.cpp:241 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:241)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'(), std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'()>, void ()>::operator()())
C/C++: >>> referenced by bindings.cpp:237 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:237)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'(), std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'()>, void ()>::operator()())
C/C++: >>> referenced by bindings.cpp:334 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:334)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_8::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'(), std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_8::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'()>, void ()>::operator()())
C/C++: >>> referenced 1 more times
C/C++: ld: error: undefined symbol: facebook::jsi::Value::Value(facebook::jsi::Value&&)
C/C++: >>> referenced by jsi-inl.h:272 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native/ReactAndroid/build/prefab-headers/jsi/jsi/jsi-inl.h:272)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'(), std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_6::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int) const::'lambda'()::operator()() const::'lambda'()>, void ()>::operator()())
C/C++: >>> referenced by bindings.cpp:353 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:353)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_8, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_8>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced by bindings.cpp:424 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:424)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_10, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_10>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: ld: error: undefined symbol: facebook::jsi::Object::asArray(facebook::jsi::Runtime&) &&
C/C++: >>> referenced by bindings.cpp:277 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:277)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_7, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_7>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced by bindings.cpp:311 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp:311)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/bindings.cpp.o:(std::__ndk1::__function::__func<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_8, std::__ndk1::allocator<osp::install(facebook::jsi::Runtime&, std::__ndk1::shared_ptr<facebook::react::CallInvoker>, char const*)::$_8>, facebook::jsi::Value (facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*, unsigned int)>::operator()(facebook::jsi::Runtime&, facebook::jsi::Value const&, facebook::jsi::Value const*&&, unsigned int&&))
C/C++: >>> referenced by JSIHelper.cpp:76 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/JSIHelper.cpp:76)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/JSIHelper.cpp.o:(jsiQueryArgumentsToSequelParam(facebook::jsi::Runtime&, facebook::jsi::Value const&, std::__ndk1::vector<QuickValue, std::__ndk1::allocator<QuickValue> >*))
C/C++: >>> referenced 4 more times
C/C++: ld: error: undefined symbol: facebook::jsi::Value::asNumber() const
C/C++: >>> referenced by JSIHelper.cpp:92 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/JSIHelper.cpp:92)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/JSIHelper.cpp.o:(jsiQueryArgumentsToSequelParam(facebook::jsi::Runtime&, facebook::jsi::Value const&, std::__ndk1::vector<QuickValue, std::__ndk1::allocator<QuickValue> >*))
C/C++: ld: error: undefined symbol: facebook::jsi::Value::asObject(facebook::jsi::Runtime&) &&
C/C++: >>> referenced by sqlbatchexecutor.cpp:10 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/sqlbatchexecutor.cpp:10)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/sqlbatchexecutor.cpp.o:(jsiBatchParametersToQuickArguments(facebook::jsi::Runtime&, facebook::jsi::Array const&, std::__ndk1::vector<QuickQueryArguments, std::__ndk1::allocator<QuickQueryArguments> >*))
C/C++: ld: error: undefined symbol: facebook::jsi::Value::asString(facebook::jsi::Runtime&) &&
C/C++: >>> referenced by sqlbatchexecutor.cpp:16 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/sqlbatchexecutor.cpp:16)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/cpp/sqlbatchexecutor.cpp.o:(jsiBatchParametersToQuickArguments(facebook::jsi::Runtime&, facebook::jsi::Array const&, std::__ndk1::vector<QuickQueryArguments, std::__ndk1::allocator<QuickQueryArguments> >*))
C/C++: ld: error: undefined symbol: facebook::react::CallInvokerHolder::getCallInvoker()
C/C++: >>> referenced by cpp-adapter.cpp:26 (/Users/jakubpiasecki/Projects/ExpensifyLabs/node_modules/react-native-quick-sqlite/android/cpp-adapter.cpp:26)
C/C++: >>>               CMakeFiles/react-native-quick-sqlite.dir/cpp-adapter.cpp.o:(QuickSQLiteBridge::installNativeJsi(facebook::jni::alias_ref<facebook::jni::JObject>, long long, facebook::jni::alias_ref<facebook::jni::detail::JTypeFor<facebook::jni::HybridClass<facebook::react::CallInvokerHolder, facebook::jni::detail::BaseHybridClass>::JavaPart, facebook::jni::JObject, void>::_javaobject*>, facebook::jni::alias_ref<facebook::jni::JString>))
C/C++: clang++: error: linker command failed with exit code 1 (use -v to see invocation)
C/C++: ninja: build stopped: subcommand failed.
```
</details>