### PR TITLE
fix: change minSdkVersion for RN 0.74.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,7 +63,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 21 
+    minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet('targetSdkVersion', 28)
     versionCode 1
     versionName "1.0"


### PR DESCRIPTION
React Native 0.74.1 added [the minimum SDK version bump to 23](https://reactnative.dev/blog/2024/04/22/release-0.74#android-minimum-sdk-bump-android-60). This PR tends to add the same, making sure the previous 21 is intact.

Also, fixes #42 