### PR TITLE
feat: remove usage of currentBridge

### DIFF
--- a/package/ios/QuickSQLite.mm
+++ b/package/ios/QuickSQLite.mm
@@ -12,12 +12,12 @@
 
 RCT_EXPORT_MODULE(QuickSQLite)
 
+@synthesize bridge = _bridge;
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
   NSLog(@"Installing QuickSQLite module...");
 
-  RCTBridge *bridge = [RCTBridge currentBridge];
-  RCTCxxBridge *cxxBridge = (RCTCxxBridge *)bridge;
+  RCTCxxBridge *cxxBridge = (RCTCxxBridge *)self.bridge;
   if (cxxBridge == nil) {
     return @false;
   }
@@ -29,7 +29,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
     return @false;
   }
   auto &runtime = *jsiRuntime;
-  auto callInvoker = bridge.jsCallInvoker;
+  auto callInvoker = cxxBridge.jsCallInvoker;
 
   // Get appGroupID value from Info.plist using key "AppGroup"
   NSString *appGroupID = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"ReactNativeQuickSQLite_AppGroup"];


### PR DESCRIPTION
## PR concerning New Architecture support in the library :tada:

We at [Software Mansion](https://swmansion.com/) have been working on [improving support](https://blog.swmansion.com/sunrising-new-architecture-in-the-new-expensify-app-729d237a02f5) for the new architecture for quite a while now. If you need help with anything related to New Architecture, like:
- [migrating your library](https://x.com/swmansion/status/1717512089323864275)
- [migrating your app](https://github.com/Expensify/App/pull/13767)
- [investigating issues](https://github.com/facebook/react-native/pulls?q=sort%3Aupdated-desc+is%3Apr+author%3Aj-piasecki+is%3Aopen)
- [improving performance](https://x.com/BBloniarz_/status/1808138585528303977)

or you just want to ask any questions, hit us up on [projects@swmansion.com](mailto:projects@swmansion.com)

---

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

### Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

We don't have to use `[RCTBridge currentBridge]` when we `synthesize` the bridge and just use it. On bridgeless it will resolve in `RCTBridgeProxy` which has access to `runtime` and `jsCallInvoker`