### PR TITLE
Fix: Android build fails due to duplicate `*.so` files

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -94,15 +94,23 @@ android {
 
   packagingOptions {
     excludes = [
-        "META-INF",
-        "META-INF/**",
-        "**/libjsi.so",
-        "**/libc++_shared.so",
-        "**/libreact_nativemodule_core.so",
-        "**/libturbomodulejsijni.so"
+      "META-INF",
+      "META-INF/**",
+      "**/libc++_shared.so",
+      "**/libfbjni.so",
+      "**/libjsi.so",
+      "**/libfolly_json.so",
+      "**/libfolly_runtime.so",
+      "**/libglog.so",
+      "**/libhermes.so",
+      "**/libhermes-executor-debug.so",
+      "**/libhermes_executor.so",
+      "**/libreactnativejni.so",
+      "**/libturbomodulejsijni.so",
+      "**/libreact_nativemodule_core.so",
+      "**/libjscexecutor.so"
     ]
   }
-
 }
 
 repositories {

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -91,6 +91,18 @@ android {
       }
     }
   }
+
+  packagingOptions {
+    excludes = [
+        "META-INF",
+        "META-INF/**",
+        "**/libjsi.so",
+        "**/libc++_shared.so",
+        "**/libreact_nativemodule_core.so",
+        "**/libturbomodulejsijni.so"
+    ]
+  }
+
 }
 
 repositories {


### PR DESCRIPTION
Fixes https://github.com/margelo/react-native-quick-sqlite/issues/65

Fixes an issue with Android builds, where multiple `*.so` files are found and therefore the build will fail.