### PR TITLE
fix: Use proper move semantics for `HybridNativeQueryResult`

### DIFF
--- a/package/cpp/specs/HybridNativeQueryResult.hpp
+++ b/package/cpp/specs/HybridNativeQueryResult.hpp
@@ -11,7 +11,7 @@ namespace margelo::nitro::rnnitrosqlite {
 class HybridNativeQueryResult : public HybridNativeQueryResultSpec {
 public:
   HybridNativeQueryResult() : HybridObject(TAG) {}
-  HybridNativeQueryResult(std::optional<double> insertId, int rowsAffected, SQLiteQueryResults& results, std::optional<SQLiteQueryTableMetadata>& metadata)
+  HybridNativeQueryResult(std::optional<double> insertId, int rowsAffected, SQLiteQueryResults&& results, std::optional<SQLiteQueryTableMetadata>&& metadata)
       : HybridObject(TAG),
         _insertId(insertId),
         _rowsAffected(rowsAffected),
@@ -27,11 +27,11 @@ private:
 public:
   // Properties
   std::optional<double> getInsertId() override;
-  
+
   double getRowsAffected() override;
-  
+
   SQLiteQueryResults getResults() override;
-  
+
   std::optional<SQLiteQueryTableMetadata> getMetadata() override;
 };
 


### PR DESCRIPTION
Moving a borrowed reference (`&`) is unsafe and not expected by the caller.