### PR TITLE
chore: Update JDK version to 17 (`compileOptions` in Gradle config)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "react-native-nitro-sqlite-workspace",

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -140,8 +140,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
   }
 
   sourceSets {


### PR DESCRIPTION
I removed some legacy code still targeting JDK 8, although this has not been compiled with that JDK version recently:

```groovy
  compileOptions {
    sourceCompatibility JavaVersion.VERSION_1_8
    targetCompatibility JavaVersion.VERSION_1_8
  }
```