### PR TITLE
fix: Keep hybrid object data

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(find:*)",
+      "Bash(grep:*)"
+    ]
+  }
+}

--- a/package/cpp/NitroSQLiteException.hpp
+++ b/package/cpp/NitroSQLiteException.hpp
@@ -2,11 +2,10 @@
 
 #include <exception>
 #include <iostream>
-#include <string>
 #include <optional>
+#include <string>
 
 const std::string NITRO_SQLITE_EXCEPTION_PREFIX = "[NativeNitroSQLiteException]";
-
 
 enum NitroSQLiteExceptionType {
   UnknownError,

--- a/package/cpp/operations.cpp
+++ b/package/cpp/operations.cpp
@@ -11,6 +11,7 @@
 #include <sqlite3.h>
 #include <sstream>
 #include <unistd.h>
+#include "specs/HybridNitroSQLiteQueryResult.hpp"
 
 using namespace facebook;
 using namespace margelo::nitro;
@@ -121,7 +122,7 @@ void bindStatement(sqlite3_stmt* statement, const SQLiteQueryParams& values) {
   }
 }
 
-SQLiteExecuteQueryResult sqliteExecute(const std::string& dbName, const std::string& query,
+std::shared_ptr<HybridNitroSQLiteQueryResult> sqliteExecute(const std::string& dbName, const std::string& query,
                                        const std::optional<SQLiteQueryParams>& params) {
   if (dbMap.count(dbName) == 0) {
     throw NitroSQLiteException::DatabaseNotOpen(dbName);
@@ -229,10 +230,7 @@ SQLiteExecuteQueryResult sqliteExecute(const std::string& dbName, const std::str
 
   int rowsAffected = sqlite3_changes(db);
   long long latestInsertRowId = sqlite3_last_insert_rowid(db);
-  return {.rowsAffected = rowsAffected,
-          .insertId = static_cast<double>(latestInsertRowId),
-          .results = std::move(results),
-          .metadata = std::move(metadata)};
+  return std::make_shared<HybridNitroSQLiteQueryResult>(results, static_cast<double>(latestInsertRowId), rowsAffected, metadata);
 }
 
 SQLiteOperationResult sqliteExecuteLiteral(const std::string& dbName, const std::string& query) {
@@ -288,3 +286,4 @@ SQLiteOperationResult sqliteExecuteLiteral(const std::string& dbName, const std:
 }
 
 } // namespace margelo::rnnitrosqlite
+

--- a/package/cpp/operations.cpp
+++ b/package/cpp/operations.cpp
@@ -1,6 +1,7 @@
 #include "operations.hpp"
 #include "NitroSQLiteException.hpp"
 #include "logs.hpp"
+#include "specs/HybridNitroSQLiteQueryResult.hpp"
 #include "utils.hpp"
 #include <NitroModules/ArrayBuffer.hpp>
 #include <cmath>
@@ -11,7 +12,6 @@
 #include <sqlite3.h>
 #include <sstream>
 #include <unistd.h>
-#include "specs/HybridNitroSQLiteQueryResult.hpp"
 
 using namespace facebook;
 using namespace margelo::nitro;
@@ -123,7 +123,7 @@ void bindStatement(sqlite3_stmt* statement, const SQLiteQueryParams& values) {
 }
 
 std::shared_ptr<HybridNitroSQLiteQueryResult> sqliteExecute(const std::string& dbName, const std::string& query,
-                                       const std::optional<SQLiteQueryParams>& params) {
+                                                            const std::optional<SQLiteQueryParams>& params) {
   if (dbMap.count(dbName) == 0) {
     throw NitroSQLiteException::DatabaseNotOpen(dbName);
   }
@@ -286,4 +286,3 @@ SQLiteOperationResult sqliteExecuteLiteral(const std::string& dbName, const std:
 }
 
 } // namespace margelo::rnnitrosqlite
-

--- a/package/cpp/operations.hpp
+++ b/package/cpp/operations.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "types.hpp"
+#include "specs/HybridNitroSQLiteQueryResult.hpp"
 
 namespace margelo::rnnitrosqlite {
 
@@ -15,7 +16,7 @@ void sqliteAttachDb(const std::string& mainDBName, const std::string& docPath, c
 
 void sqliteDetachDb(const std::string& mainDBName, const std::string& alias);
 
-SQLiteExecuteQueryResult sqliteExecute(const std::string& dbName, const std::string& query, const std::optional<SQLiteQueryParams>& params);
+std::shared_ptr<HybridNitroSQLiteQueryResult> sqliteExecute(const std::string& dbName, const std::string& query, const std::optional<SQLiteQueryParams>& params);
 
 SQLiteOperationResult sqliteExecuteLiteral(const std::string& dbName, const std::string& query);
 

--- a/package/cpp/operations.hpp
+++ b/package/cpp/operations.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "types.hpp"
 #include "specs/HybridNitroSQLiteQueryResult.hpp"
+#include "types.hpp"
 
 namespace margelo::rnnitrosqlite {
 
@@ -16,7 +16,8 @@ void sqliteAttachDb(const std::string& mainDBName, const std::string& docPath, c
 
 void sqliteDetachDb(const std::string& mainDBName, const std::string& alias);
 
-std::shared_ptr<HybridNitroSQLiteQueryResult> sqliteExecute(const std::string& dbName, const std::string& query, const std::optional<SQLiteQueryParams>& params);
+std::shared_ptr<HybridNitroSQLiteQueryResult> sqliteExecute(const std::string& dbName, const std::string& query,
+                                                            const std::optional<SQLiteQueryParams>& params);
 
 SQLiteOperationResult sqliteExecuteLiteral(const std::string& dbName, const std::string& query);
 

--- a/package/cpp/specs/HybridNitroSQLite.cpp
+++ b/package/cpp/specs/HybridNitroSQLite.cpp
@@ -10,6 +10,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include "HybridNitroSQLiteQueryResult.hpp"
 
 namespace margelo::nitro::rnnitrosqlite {
 
@@ -50,12 +51,9 @@ void HybridNitroSQLite::detach(const std::string& mainDbName, const std::string&
   sqliteDetachDb(mainDbName, alias);
 };
 
-using ExecuteQueryResult = std::shared_ptr<HybridNitroSQLiteQueryResultSpec>;
-
-ExecuteQueryResult HybridNitroSQLite::execute(const std::string& dbName, const std::string& query,
+std::shared_ptr<HybridNitroSQLiteQueryResultSpec> HybridNitroSQLite::execute(const std::string& dbName, const std::string& query,
                                               const std::optional<SQLiteQueryParams>& params) {
-  SQLiteExecuteQueryResult result = sqliteExecute(dbName, query, params);
-  return std::make_shared<HybridNitroSQLiteQueryResult>(std::move(result));
+  return sqliteExecute(dbName, query, params);
 };
 
 std::shared_ptr<Promise<std::shared_ptr<HybridNitroSQLiteQueryResultSpec>>>

--- a/package/cpp/specs/HybridNitroSQLite.cpp
+++ b/package/cpp/specs/HybridNitroSQLite.cpp
@@ -10,7 +10,6 @@
 #include <map>
 #include <string>
 #include <vector>
-#include "HybridNitroSQLiteQueryResult.hpp"
 
 namespace margelo::nitro::rnnitrosqlite {
 
@@ -52,7 +51,7 @@ void HybridNitroSQLite::detach(const std::string& mainDbName, const std::string&
 };
 
 std::shared_ptr<HybridNitroSQLiteQueryResultSpec> HybridNitroSQLite::execute(const std::string& dbName, const std::string& query,
-                                              const std::optional<SQLiteQueryParams>& params) {
+                                                                             const std::optional<SQLiteQueryParams>& params) {
   return sqliteExecute(dbName, query, params);
 };
 

--- a/package/cpp/specs/HybridNitroSQLiteQueryResult.cpp
+++ b/package/cpp/specs/HybridNitroSQLiteQueryResult.cpp
@@ -9,41 +9,23 @@
 namespace margelo::nitro::rnnitrosqlite {
 
 std::optional<double> HybridNitroSQLiteQueryResult::getInsertId() {
-  return _result.insertId;
+  return _insertId;
 }
 
 double HybridNitroSQLiteQueryResult::getRowsAffected() {
-  return _result.rowsAffected;
+  return _rowsAffected;
 }
 
 SQLiteQueryResults HybridNitroSQLiteQueryResult::getResults() {
-  return _result.results;
+  return _results;
 };
 
 std::optional<NitroSQLiteQueryResultRows> HybridNitroSQLiteQueryResult::getRows() {
-  if (_result.results.empty()) {
-    return std::nullopt;
-  }
-  
-  auto rows = _result.results;
-
-  // Create the item function that returns a Promise
-  auto itemFunction = [rows](double idx) -> std::shared_ptr<Promise<std::optional<SQLiteQueryResultRow>>> {
-    return Promise<std::optional<SQLiteQueryResultRow>>::async([rows, idx]() -> std::optional<SQLiteQueryResultRow> {
-      const auto index = static_cast<size_t>(idx);
-      if (index >= rows.size()) {
-        return std::nullopt;
-      }
-      return rows[index];
-    });
-  };
-
-  const auto length = static_cast<double>(rows.size());
-  return NitroSQLiteQueryResultRows(std::move(rows), length, itemFunction);
+  return _rows;
 }
 
 std::optional<SQLiteQueryTableMetadata> HybridNitroSQLiteQueryResult::getMetadata() {
-  return _result.metadata;
+  return _metadata;
 }
 
 } // namespace margelo::nitro::rnnitrosqlite

--- a/package/cpp/specs/HybridNitroSQLiteQueryResult.hpp
+++ b/package/cpp/specs/HybridNitroSQLiteQueryResult.hpp
@@ -11,37 +11,28 @@ namespace margelo::nitro::rnnitrosqlite {
 class HybridNitroSQLiteQueryResult : public HybridNitroSQLiteQueryResultSpec {
 public:
   HybridNitroSQLiteQueryResult() : HybridObject(TAG) {}
-  HybridNitroSQLiteQueryResult(SQLiteQueryResults results,
-                               std::optional<double> insertId,
-                               double rowsAffected,
+  HybridNitroSQLiteQueryResult(SQLiteQueryResults results, std::optional<double> insertId, double rowsAffected,
                                std::optional<SQLiteQueryTableMetadata> metadata)
-      : HybridObject(TAG),
-        _insertId(insertId),
-        _rowsAffected(rowsAffected),
-        _results(std::move(results)),
-        _metadata(metadata) {
+      : HybridObject(TAG), _insertId(insertId), _rowsAffected(rowsAffected), _results(std::move(results)), _metadata(metadata) {
     if (_results.empty()) {
       // Empty rows: empty vector, length 0, item callback always returns null
       auto emptyItem = [](double /* idx */) -> std::shared_ptr<Promise<std::optional<SQLiteQueryResultRow>>> {
-        return Promise<std::optional<SQLiteQueryResultRow>>::async(
-            []() -> std::optional<SQLiteQueryResultRow> { return std::nullopt; });
+        return Promise<std::optional<SQLiteQueryResultRow>>::async([]() -> std::optional<SQLiteQueryResultRow> { return std::nullopt; });
       };
       _rows = NitroSQLiteQueryResultRows(SQLiteQueryResults{}, 0.0, std::move(emptyItem));
       return;
     }
 
     auto rows = _results;
-    auto itemFunction =
-        [rows](double idx) -> std::shared_ptr<Promise<std::optional<SQLiteQueryResultRow>>> {
-          return Promise<std::optional<SQLiteQueryResultRow>>::async(
-              [rows, idx]() -> std::optional<SQLiteQueryResultRow> {
-                const auto index = static_cast<size_t>(idx);
-                if (index >= rows.size()) {
-                  return std::nullopt;
-                }
-                return rows[index];
-              });
-        };
+    auto itemFunction = [rows](double idx) -> std::shared_ptr<Promise<std::optional<SQLiteQueryResultRow>>> {
+      return Promise<std::optional<SQLiteQueryResultRow>>::async([rows, idx]() -> std::optional<SQLiteQueryResultRow> {
+        const auto index = static_cast<size_t>(idx);
+        if (index >= rows.size()) {
+          return std::nullopt;
+        }
+        return rows[index];
+      });
+    };
 
     const auto length = static_cast<double>(rows.size());
     _rows = NitroSQLiteQueryResultRows(std::move(rows), length, std::move(itemFunction));
@@ -52,7 +43,7 @@ private:
   double _rowsAffected;
   SQLiteQueryResults _results;
   std::optional<NitroSQLiteQueryResultRows> _rows;
-  std::optional<SQLiteQueryTableMetadata>_metadata;
+  std::optional<SQLiteQueryTableMetadata> _metadata;
 
 public:
   // Properties

--- a/package/cpp/specs/HybridNitroSQLiteQueryResult.hpp
+++ b/package/cpp/specs/HybridNitroSQLiteQueryResult.hpp
@@ -11,10 +11,40 @@ namespace margelo::nitro::rnnitrosqlite {
 class HybridNitroSQLiteQueryResult : public HybridNitroSQLiteQueryResultSpec {
 public:
   HybridNitroSQLiteQueryResult() : HybridObject(TAG) {}
-  HybridNitroSQLiteQueryResult(SQLiteExecuteQueryResult&& result) : HybridObject(TAG), _result(std::move(result)) {}
+  HybridNitroSQLiteQueryResult(SQLiteQueryResults results, std::optional<double> insertId, double rowsAffected, std::optional<SQLiteQueryTableMetadata> metadata) {
+    HybridNitroSQLiteQueryResult();
+    
+    _results = results;
+    _insertId = insertId;
+    _metadata = metadata;
+    
+    if (!_results.empty()) {
+      auto rows = _results;
+
+      // Create the item function that returns a Promise
+      auto itemFunction = [rows](double idx) -> std::shared_ptr<Promise<std::optional<SQLiteQueryResultRow>>> {
+        return Promise<std::optional<SQLiteQueryResultRow>>::async([rows, idx]() -> std::optional<SQLiteQueryResultRow> {
+          const auto index = static_cast<size_t>(idx);
+          if (index >= rows.size()) {
+            return std::nullopt;
+          }
+          return rows[index];
+        });
+      };
+
+      const auto length = static_cast<double>(rows.size());
+      _rows = NitroSQLiteQueryResultRows(std::move(rows), length, itemFunction);
+    }
+    
+    
+  }
 
 private:
-  SQLiteExecuteQueryResult _result;
+  std::optional<double> _insertId;
+  double _rowsAffected;
+  SQLiteQueryResults _results;
+  std::optional<NitroSQLiteQueryResultRows> _rows;
+  std::optional<SQLiteQueryTableMetadata>_metadata;
 
 public:
   // Properties

--- a/package/cpp/specs/HybridNitroSQLiteQueryResult.hpp
+++ b/package/cpp/specs/HybridNitroSQLiteQueryResult.hpp
@@ -11,32 +11,40 @@ namespace margelo::nitro::rnnitrosqlite {
 class HybridNitroSQLiteQueryResult : public HybridNitroSQLiteQueryResultSpec {
 public:
   HybridNitroSQLiteQueryResult() : HybridObject(TAG) {}
-  HybridNitroSQLiteQueryResult(SQLiteQueryResults results, std::optional<double> insertId, double rowsAffected, std::optional<SQLiteQueryTableMetadata> metadata) {
-    HybridNitroSQLiteQueryResult();
-    
-    _results = results;
-    _insertId = insertId;
-    _metadata = metadata;
-    
-    if (!_results.empty()) {
-      auto rows = _results;
-
-      // Create the item function that returns a Promise
-      auto itemFunction = [rows](double idx) -> std::shared_ptr<Promise<std::optional<SQLiteQueryResultRow>>> {
-        return Promise<std::optional<SQLiteQueryResultRow>>::async([rows, idx]() -> std::optional<SQLiteQueryResultRow> {
-          const auto index = static_cast<size_t>(idx);
-          if (index >= rows.size()) {
-            return std::nullopt;
-          }
-          return rows[index];
-        });
+  HybridNitroSQLiteQueryResult(SQLiteQueryResults results,
+                               std::optional<double> insertId,
+                               double rowsAffected,
+                               std::optional<SQLiteQueryTableMetadata> metadata)
+      : HybridObject(TAG),
+        _insertId(insertId),
+        _rowsAffected(rowsAffected),
+        _results(std::move(results)),
+        _metadata(metadata) {
+    if (_results.empty()) {
+      // Empty rows: empty vector, length 0, item callback always returns null
+      auto emptyItem = [](double /* idx */) -> std::shared_ptr<Promise<std::optional<SQLiteQueryResultRow>>> {
+        return Promise<std::optional<SQLiteQueryResultRow>>::async(
+            []() -> std::optional<SQLiteQueryResultRow> { return std::nullopt; });
       };
-
-      const auto length = static_cast<double>(rows.size());
-      _rows = NitroSQLiteQueryResultRows(std::move(rows), length, itemFunction);
+      _rows = NitroSQLiteQueryResultRows(SQLiteQueryResults{}, 0.0, std::move(emptyItem));
+      return;
     }
-    
-    
+
+    auto rows = _results;
+    auto itemFunction =
+        [rows](double idx) -> std::shared_ptr<Promise<std::optional<SQLiteQueryResultRow>>> {
+          return Promise<std::optional<SQLiteQueryResultRow>>::async(
+              [rows, idx]() -> std::optional<SQLiteQueryResultRow> {
+                const auto index = static_cast<size_t>(idx);
+                if (index >= rows.size()) {
+                  return std::nullopt;
+                }
+                return rows[index];
+              });
+        };
+
+    const auto length = static_cast<double>(rows.size());
+    _rows = NitroSQLiteQueryResultRows(std::move(rows), length, std::move(itemFunction));
   }
 
 private:

--- a/package/cpp/sqliteExecuteBatch.cpp
+++ b/package/cpp/sqliteExecuteBatch.cpp
@@ -49,7 +49,7 @@ SQLiteOperationResult sqliteExecuteBatch(const std::string& dbName, const std::v
       auto metadata = std::optional<SQLiteQueryTableMetadata>(std::nullopt);
       try {
         auto result = sqliteExecute(dbName, command.sql, command.params);
-        rowsAffected += result.rowsAffected;
+        rowsAffected += result->getRowsAffected();
       } catch (NitroSQLiteException& e) {
         sqliteExecuteLiteral(dbName, "ROLLBACK");
         throw e;

--- a/package/cpp/types.hpp
+++ b/package/cpp/types.hpp
@@ -18,16 +18,7 @@ using SQLiteQueryTableMetadata = std::unordered_map<std::string, NitroSQLiteQuer
 
 struct SQLiteOperationResult {
   int rowsAffected;
-  double insertId;
-  int commands;
-};
-
-struct SQLiteExecuteQueryResult {
-  int rowsAffected;
-  double insertId;
-
-  SQLiteQueryResults results;
-  std::optional<SQLiteQueryTableMetadata> metadata;
+  int commands = 0;
 };
 
 // constexpr function that maps SQLiteColumnType to string literals

--- a/package/src/operations/execute.ts
+++ b/package/src/operations/execute.ts
@@ -1,5 +1,4 @@
 import { HybridNitroSQLite } from '../nitro'
-import type { NitroSQLiteQueryResult } from '../specs/NitroSQLiteQueryResult.nitro'
 import type { QueryResult, QueryResultRow, SQLiteQueryParams } from '../types'
 import NitroSQLiteError from '../NitroSQLiteError'
 
@@ -10,7 +9,7 @@ export function execute<Row extends QueryResultRow = never>(
 ): QueryResult<Row> {
   try {
     const result = HybridNitroSQLite.execute(dbName, query, params)
-    return buildJsQueryResult<Row>(result)
+    return result as QueryResult<Row>
   } catch (error) {
     throw NitroSQLiteError.fromError(error)
   }
@@ -23,25 +22,8 @@ export async function executeAsync<Row extends QueryResultRow = never>(
 ): Promise<QueryResult<Row>> {
   try {
     const result = await HybridNitroSQLite.executeAsync(dbName, query, params)
-    return buildJsQueryResult<Row>(result)
+    return result as QueryResult<Row>
   } catch (error) {
     throw NitroSQLiteError.fromError(error)
   }
-}
-
-function buildJsQueryResult<Row extends QueryResultRow = never>(
-  result: NitroSQLiteQueryResult,
-): QueryResult<Row> {
-  const data = result.results as Row[]
-
-  return {
-    ...result,
-    insertId: result.insertId,
-    rowsAffected: result.rowsAffected,
-    rows: {
-      _array: data,
-      length: data.length,
-      item: (idx: number) => data[idx],
-    },
-  } as QueryResult<Row>
 }

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -1,5 +1,4 @@
 import type {
-  NitroSQLiteQueryColumnMetadata,
   NitroSQLiteQueryResult,
   NitroSQLiteQueryResultRows,
 } from './specs/NitroSQLiteQueryResult.nitro'
@@ -42,17 +41,8 @@ export type QueryResultRow = Record<string, SQLiteValue>
 
 export type QueryResult<Row extends QueryResultRow = QueryResultRow> =
   NitroSQLiteQueryResult & {
-    readonly rowsAffected: number
-    readonly insertId?: number
-
-    /** Query results */
-    readonly results: Row[]
-
     /** Query results in a row format for TypeORM compatibility */
-    readonly rows?: NitroSQLiteQueryResultRows<Row>
-
-    /** Table metadata */
-    readonly metadata?: Record<string, NitroSQLiteQueryColumnMetadata>
+    rows?: NitroSQLiteQueryResultRows<Row>
   }
 
 export type ExecuteQuery = <Row extends QueryResultRow = QueryResultRow>(


### PR DESCRIPTION
Make sure that the data from Nitro hybrid objects is directly passed to the user-facing JS API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the native-to-JS return path for `execute`/`executeAsync` by returning a shared `HybridNitroSQLiteQueryResult` instead of a copied JS-built object, which could affect result shape/lifetime and batch row counts.
> 
> **Overview**
> **Passes Nitro hybrid query results through to JS without rebuilding them.** Native `sqliteExecute()` now returns a `HybridNitroSQLiteQueryResult` directly (removing `SQLiteExecuteQueryResult`), and `HybridNitroSQLite::execute()` just forwards that shared hybrid object.
> 
> `HybridNitroSQLiteQueryResult` now stores `insertId`, `rowsAffected`, `results`, `rows`, and `metadata` as its own fields and constructs the `rows` accessor up front (including an empty-rows case). JS `execute`/`executeAsync` stop constructing a new result object and instead return the hybrid object as-is, and TypeScript types are simplified to rely on the Nitro spec (only specializing `rows` generics).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 078f30d7931aacc3d3860ae02fb9f0d055c2e2bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->