### PR TITLE
Update the release pipeline for both packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version or increment"
+        required: true
+        default: "patch"
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Publish packages and GitHub release
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ secrets.RELEASE_IT_GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Setup Ruby (bundle)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.0
+          bundler-cache: true
+          working-directory: example
+
+      - name: Select Xcode 26.5
+        run: sudo xcode-select -s "/Applications/Xcode_26.5.app/Contents/Developer"
+
+      - name: Install npm dependencies (bun)
+        run: bun install
+
+      - name: Configure Git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Release
+        run: bun release "${{ inputs.version }}" --ci --no-git.requireUpstream
+        env:
+          RELEASE_IT_GITHUB_TOKEN: ${{ secrets.RELEASE_IT_GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_CACHE: ${{ runner.temp }}/npm-cache
+          NPM_CONFIG_PROVENANCE: "true"

--- a/bun.lock
+++ b/bun.lock
@@ -59,7 +59,7 @@
         "react-native": "0.85.0-rc.0",
         "react-native-nitro-modules": "*",
         "react-native-nitro-sqlite": "9.6.0",
-        "react-native-nitro-sqlite-vec": "*",
+        "react-native-nitro-sqlite-vec": "9.6.0",
         "react-native-quick-base64": "^3.0.0",
         "react-native-quick-crypto": "^1.1.5",
         "react-native-safe-area-context": "^5.5.2",

--- a/example/package.json
+++ b/example/package.json
@@ -28,7 +28,7 @@
     "react-native": "0.85.0-rc.0",
     "react-native-nitro-modules": "*",
     "react-native-nitro-sqlite": "9.6.0",
-    "react-native-nitro-sqlite-vec": "*",
+    "react-native-nitro-sqlite-vec": "9.6.0",
     "react-native-quick-base64": "^3.0.0",
     "react-native-quick-crypto": "^1.1.5",
     "react-native-safe-area-context": "^5.5.2",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
       }
     },
     "hooks": {
-      "before:release": "bun example bundle-install && bun example pods && git add example/ios/Podfile.lock"
+      "before:release": "bun install --lockfile-only && bun example bundle-install && bun example pods && git add bun.lock example/ios/Podfile.lock"
     },
     "plugins": {
       "@release-it/bumper": {
@@ -94,6 +94,17 @@
           "path": "version"
         },
         "out": [
+          {
+            "file": "packages/react-native-nitro-sqlite/package.json",
+            "path": "version"
+          },
+          {
+            "file": "packages/react-native-nitro-sqlite-vec/package.json",
+            "path": [
+              "version",
+              "devDependencies.react-native-nitro-sqlite"
+            ]
+          },
           {
             "file": "package.json",
             "path": "version"
@@ -104,7 +115,10 @@
           },
           {
             "file": "example/package.json",
-            "path": "dependencies.react-native-nitro-sqlite"
+            "path": [
+              "dependencies.react-native-nitro-sqlite",
+              "dependencies.react-native-nitro-sqlite-vec"
+            ]
           }
         ]
       },

--- a/packages/react-native-nitro-sqlite-vec/package.json
+++ b/packages/react-native-nitro-sqlite-vec/package.json
@@ -15,7 +15,9 @@
   ],
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "lint": "eslint \"**/*.{js,ts,tsx}\" --fix"
+    "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
+    "release": "release-it",
+    "prepublishOnly": "bun typecheck && bun lint"
   },
   "keywords": [
     "react-native",
@@ -32,11 +34,40 @@
     "url": "git+https://github.com/margelo/react-native-nitro-sqlite.git"
   },
   "license": "MIT",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "peerDependencies": {
     "react-native-nitro-sqlite": ">=9.0.0"
   },
   "devDependencies": {
     "react-native-nitro-sqlite": "9.6.0",
     "typescript": "^5.8.3"
+  },
+  "release-it": {
+    "npm": {
+      "publish": true,
+      "versionArgs": [
+        "--allow-same-version"
+      ]
+    },
+    "git": false,
+    "github": {
+      "release": false
+    },
+    "hooks": {
+      "before:init": "bun typecheck && bun lint"
+    },
+    "plugins": {
+      "@release-it/bumper": {
+        "out": {
+          "file": "package.json",
+          "path": [
+            "version",
+            "devDependencies.react-native-nitro-sqlite"
+          ]
+        }
+      }
+    }
   }
 }

--- a/packages/react-native-nitro-sqlite-vec/package.json
+++ b/packages/react-native-nitro-sqlite-vec/package.json
@@ -17,7 +17,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "release": "release-it",
-    "prepublishOnly": "bun typecheck && bun lint"
+    "prepublishOnly": "bun typecheck"
   },
   "keywords": [
     "react-native",
@@ -47,6 +47,7 @@
   "release-it": {
     "npm": {
       "publish": true,
+      "skipChecks": true,
       "versionArgs": [
         "--allow-same-version"
       ]
@@ -56,7 +57,7 @@
       "release": false
     },
     "hooks": {
-      "before:init": "bun typecheck && bun lint"
+      "before:init": "bun typecheck"
     },
     "plugins": {
       "@release-it/bumper": {

--- a/packages/react-native-nitro-sqlite/package.json
+++ b/packages/react-native-nitro-sqlite/package.json
@@ -94,6 +94,7 @@
   "release-it": {
     "npm": {
       "publish": true,
+      "skipChecks": true,
       "versionArgs": [
         "--allow-same-version"
       ]

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,6 +7,7 @@ echo "Provided options: $*"
 
 release_it_args=("$@")
 forward_args=()
+package_args=()
 skip_next=false
 
 if [ "$#" -gt 0 ]; then
@@ -36,6 +37,13 @@ for arg in "${release_it_args_without_increment[@]}"; do
       ;;
     *)
       forward_args+=("$arg")
+      case "$arg" in
+        --git*|--no-git*|--github*|--no-github*)
+          ;;
+        *)
+          package_args+=("$arg")
+          ;;
+      esac
       ;;
   esac
 done
@@ -53,11 +61,11 @@ echo "Resolved release version: $release_version"
 
 echo "Publishing react-native-nitro-sqlite@$release_version to NPM"
 cd packages/react-native-nitro-sqlite
-bun release "$release_version" "${forward_args[@]}"
+bun release "$release_version" "${package_args[@]}"
 
 echo "Publishing react-native-nitro-sqlite-vec@$release_version to NPM"
 cd ../react-native-nitro-sqlite-vec
-bun release "$release_version" "${forward_args[@]}"
+bun release "$release_version" "${package_args[@]}"
 
 echo "Creating a Git bump commit and GitHub release"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,13 +1,68 @@
-echo "Starting the release process..."
-echo "Provided options: $@"
+#!/usr/bin/env bash
 
-echo "Publishing react-native-nitro-sqlite to NPM"
+set -euo pipefail
+
+echo "Starting the release process..."
+echo "Provided options: $*"
+
+release_it_args=("$@")
+forward_args=()
+skip_next=false
+
+if [ "$#" -gt 0 ]; then
+  case "$1" in
+    major|minor|patch|premajor|preminor|prepatch|prerelease|v[0-9]*|[0-9]*)
+      release_it_args_without_increment=("${release_it_args[@]:1}")
+      ;;
+    *)
+      release_it_args_without_increment=("${release_it_args[@]}")
+      ;;
+  esac
+else
+  release_it_args_without_increment=()
+fi
+
+for arg in "${release_it_args_without_increment[@]}"; do
+  if [ "$skip_next" = true ]; then
+    skip_next=false
+    continue
+  fi
+
+  case "$arg" in
+    --increment|-i)
+      skip_next=true
+      ;;
+    --increment=*|-i=*)
+      ;;
+    *)
+      forward_args+=("$arg")
+      ;;
+  esac
+done
+
+release_version_output="$(bun run release-it "${release_it_args[@]}" --release-version)"
+release_version="$(printf '%s\n' "$release_version_output" | tail -n 1)"
+
+if [[ ! "$release_version" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+  echo "$release_version_output"
+  echo "Could not resolve a valid release version." >&2
+  exit 1
+fi
+
+echo "Resolved release version: $release_version"
+
+echo "Publishing react-native-nitro-sqlite@$release_version to NPM"
 cd packages/react-native-nitro-sqlite
-bun release $@
+bun release "$release_version" "${forward_args[@]}"
+
+echo "Publishing react-native-nitro-sqlite-vec@$release_version to NPM"
+cd ../react-native-nitro-sqlite-vec
+bun release "$release_version" "${forward_args[@]}"
 
 echo "Creating a Git bump commit and GitHub release"
 
-cd ..
+cd ../..
 
-bun run release-it $@ && \
-echo "Successfully released react-native-nitro-sqlite!"
+bun run release-it "$release_version" "${forward_args[@]}"
+
+echo "Successfully released react-native-nitro-sqlite and react-native-nitro-sqlite-vec!"


### PR DESCRIPTION
## Summary
- Add a dedicated GitHub Actions release workflow for manual versioned releases
- Update release automation to publish both `react-native-nitro-sqlite` and `react-native-nitro-sqlite-vec`
- Keep package versions and example dependency pins aligned during release
- Add release metadata and prepublish checks to the vec package

## Testing
- Not run (not requested)
- Validated the release flow changes by inspecting the updated workflow, package release-it config, and shell release script for both package publish paths