### PR TITLE
fix: Improve memory management

### DIFF
--- a/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLiteQueryResult.cpp
+++ b/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLiteQueryResult.cpp
@@ -50,10 +50,10 @@ namespace {
    * - Metadata contents, especially the `name` string on each metadata entry.
    */
   size_t getMetadataExternalMemorySize(const SQLiteQueryTableMetadata& metadata) {
-    size_t size = 0;
+    size_t size = metadata.bucket_count() * sizeof(void*);
+    size += metadata.size() * (sizeof(SQLiteQueryTableMetadata::value_type) + nodePadding);
 
     for (const auto& [columnName, columnMeta] : metadata) {
-
       size += columnName.capacity();
       size += columnMeta.name.capacity();
     }

--- a/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLiteQueryResult.cpp
+++ b/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLiteQueryResult.cpp
@@ -10,6 +10,8 @@ namespace margelo::nitro::rnnitrosqlite {
 
 namespace {
 
+  constexpr size_t nodePadding = 24;
+
   /**
    * Compute the approximate external memory size of a single result row.
    * This includes:
@@ -18,7 +20,6 @@ namespace {
    */
   size_t getRowExternalMemorySize(const SQLiteQueryResultRow& row) {
     size_t bucketMemory = row.bucket_count() * sizeof(void*);
-    constexpr size_t nodePadding = 24;
     size_t nodesMemory = row.size() * (sizeof(std::pair<std::string, SQLiteValue>) + nodePadding);
     return bucketMemory + nodesMemory;
   }

--- a/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLiteQueryResult.hpp
+++ b/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLiteQueryResult.hpp
@@ -13,7 +13,7 @@ public:
   HybridNitroSQLiteQueryResult() : HybridObject(TAG) {}
   HybridNitroSQLiteQueryResult(SQLiteQueryResults results, std::optional<double> insertId, double rowsAffected,
                                std::optional<SQLiteQueryTableMetadata> metadata)
-      : HybridObject(TAG), _insertId(insertId), _rowsAffected(rowsAffected), _results(std::move(results)), _metadata(metadata) {}
+      : HybridObject(TAG), _insertId(insertId), _rowsAffected(rowsAffected), _results(std::move(results)), _metadata(std::move(metadata)) {}
 
 private:
   std::optional<double> _insertId;

--- a/packages/react-native-nitro-sqlite/cpp/operations.cpp
+++ b/packages/react-native-nitro-sqlite/cpp/operations.cpp
@@ -25,7 +25,6 @@ using namespace margelo::nitro::rnnitrosqlite;
 
 namespace margelo::rnnitrosqlite {
 
-
 static constexpr double kInt64MinAsDouble = static_cast<double>(std::numeric_limits<int64_t>::min());
 static constexpr double kInt64UpperBoundAsDouble = -kInt64MinAsDouble;
 
@@ -128,8 +127,7 @@ void bindStatement(sqlite3_stmt* statement, const SQLiteQueryParams& values) {
     } else if (std::holds_alternative<double>(value)) {
       // Bind whole numbers as INTEGER so vec0 rowid/pk/partition (which reject REAL) work; SQLite still coerces to REAL for REAL columns.
       double doubleValue = std::get<double>(value);
-      if (std::trunc(doubleValue) == doubleValue && doubleValue >= kInt64MinAsDouble &&
-          doubleValue < kInt64UpperBoundAsDouble) {
+      if (std::trunc(doubleValue) == doubleValue && doubleValue >= kInt64MinAsDouble && doubleValue < kInt64UpperBoundAsDouble) {
         sqlite3_bind_int64(statement, sqliteIndex, static_cast<sqlite3_int64>(doubleValue));
       } else {
         sqlite3_bind_double(statement, sqliteIndex, doubleValue);


### PR DESCRIPTION
## Summary
- move query result containers into the HybridObject to avoid extra peak memory copies
- avoid building full query result objects during batch execution when only rowsAffected is needed