### PR TITLE
fix(ios): enable SQLite performance mode

### DIFF
--- a/packages/react-native-nitro-sqlite/RNNitroSQLite.podspec
+++ b/packages/react-native-nitro-sqlite/RNNitroSQLite.podspec
@@ -2,6 +2,9 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1'
+log_message = lambda do |message|
+  puts "\e[34m#{message}\e[0m"
+end
 
 # TODO: Should be customizable in package.json.
 # Used to create comparable benchmark results
@@ -49,10 +52,10 @@ Pod::Spec.new do |s|
   optimizedCflags = '$(inherited) -DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1 -DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1 -DSQLITE_MAX_EXPR_DEPTH=0 -DSQLITE_OMIT_DEPRECATED=1 -DSQLITE_OMIT_PROGRESS_CALLBACK=1 -DSQLITE_OMIT_SHARED_CACHE=1 -DSQLITE_USE_ALLOCA=1'
 
   if performance_mode == 1
-    Pod::UI.puts "Thread unsafe (1) performance mode enabled. Use only transactions! 🚀🚀"
+    log_message.call("Thread unsafe (1) performance mode enabled. Use only transactions! 🚀🚀")
     xcconfig["OTHER_CFLAGS"] = optimizedCflags + ' -DSQLITE_THREADSAFE=0 '
   elsif performance_mode == 2
-    Pod::UI.puts "Thread safe (2) performance mode enabled 🚀"
+    log_message.call("Thread safe (2) performance mode enabled 🚀")
     xcconfig["OTHER_CFLAGS"] = optimizedCflags + ' -DSQLITE_THREADSAFE=1 '
   end
 

--- a/packages/react-native-nitro-sqlite/RNNitroSQLite.podspec
+++ b/packages/react-native-nitro-sqlite/RNNitroSQLite.podspec
@@ -48,14 +48,12 @@ Pod::Spec.new do |s|
 
   optimizedCflags = '$(inherited) -DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1 -DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1 -DSQLITE_MAX_EXPR_DEPTH=0 -DSQLITE_OMIT_DEPRECATED=1 -DSQLITE_OMIT_PROGRESS_CALLBACK=1 -DSQLITE_OMIT_SHARED_CACHE=1 -DSQLITE_USE_ALLOCA=1'
 
-  if performance_mode == '1' then
+  if performance_mode == 1
     log_message.call("Thread unsafe (1) performance mode enabled. Use only transactions! 🚀🚀")
-    xcconfig[:OTHER_CFLAGS] = optimizedCflags + ' -DSQLITE_THREADSAFE=0 '
-  end
-
-  if performance_mode == '2' then
+    s.pod_target_xcconfig["OTHER_CFLAGS"] = optimizedCflags + ' -DSQLITE_THREADSAFE=0 '
+  elsif performance_mode == 2
     log_message.call("Thread safe (2) performance mode enabled 🚀")
-    xcconfig[:OTHER_CFLAGS] = optimizedCflags + ' -DSQLITE_THREADSAFE=1 '
+    s.pod_target_xcconfig["OTHER_CFLAGS"] = optimizedCflags + ' -DSQLITE_THREADSAFE=1 '
   end
 
   if ENV['NITRO_SQLITE_USE_PHONE_VERSION'] == '1' then

--- a/packages/react-native-nitro-sqlite/RNNitroSQLite.podspec
+++ b/packages/react-native-nitro-sqlite/RNNitroSQLite.podspec
@@ -33,7 +33,17 @@ Pod::Spec.new do |s|
     "cpp/**/*.{h,hpp,c,cpp}"
   ]
 
-  xcconfig = {
+  optimizedCflags = '$(inherited) -DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1 -DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1 -DSQLITE_MAX_EXPR_DEPTH=0 -DSQLITE_OMIT_DEPRECATED=1 -DSQLITE_OMIT_PROGRESS_CALLBACK=1 -DSQLITE_OMIT_SHARED_CACHE=1 -DSQLITE_USE_ALLOCA=1'
+
+  if performance_mode == 1
+    log_message.call("Thread unsafe (1) performance mode enabled. Use only transactions! 🚀🚀")
+    other_cflags = optimizedCflags + ' -DSQLITE_THREADSAFE=0 '
+  elsif performance_mode == 2
+    log_message.call("Thread safe (2) performance mode enabled 🚀")
+    other_cflags = optimizedCflags + ' -DSQLITE_THREADSAFE=1 '
+  end
+
+  s.pod_target_xcconfig = {
     :GCC_PREPROCESSOR_DEFINITIONS => "HAVE_FULLFSYNC=1",
     :WARNING_CFLAGS => "-Wno-shorten-64-to-32 -Wno-comma -Wno-unreachable-code -Wno-conditional-uninitialized -Wno-deprecated-declarations",
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20',
@@ -42,24 +52,13 @@ Pod::Spec.new do |s|
     "HEADER_SEARCH_PATHS" => "\"${PODS_ROOT}/RCT-Folly\"" + (nitro_sqlite_vec ? " \"#{nitro_sqlite_vec_cpp}\"" : ""),
     "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) FOLLY_NO_CONFIG FOLLY_CFG_NO_COROUTINES" + (nitro_sqlite_vec ? " NITRO_SQLITE_VEC=1" : ""),
     "OTHER_CPLUSPLUSFLAGS" => folly_compiler_flags,
+    "OTHER_CFLAGS" => other_cflags,
   }
 
   load 'nitrogen/generated/ios/RNNitroSQLite+autolinking.rb'
   add_nitrogen_files(s)
 
   install_modules_dependencies(s)
-
-  optimizedCflags = '$(inherited) -DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1 -DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1 -DSQLITE_MAX_EXPR_DEPTH=0 -DSQLITE_OMIT_DEPRECATED=1 -DSQLITE_OMIT_PROGRESS_CALLBACK=1 -DSQLITE_OMIT_SHARED_CACHE=1 -DSQLITE_USE_ALLOCA=1'
-
-  if performance_mode == 1
-    log_message.call("Thread unsafe (1) performance mode enabled. Use only transactions! 🚀🚀")
-    xcconfig["OTHER_CFLAGS"] = optimizedCflags + ' -DSQLITE_THREADSAFE=0 '
-  elsif performance_mode == 2
-    log_message.call("Thread safe (2) performance mode enabled 🚀")
-    xcconfig["OTHER_CFLAGS"] = optimizedCflags + ' -DSQLITE_THREADSAFE=1 '
-  end
-
-  s.pod_target_xcconfig = xcconfig
 
   if ENV['NITRO_SQLITE_USE_PHONE_VERSION'] == '1' then
     s.exclude_files = "cpp/sqlite/sqlite3.c", "cpp/sqlite/sqlite3.h"

--- a/packages/react-native-nitro-sqlite/RNNitroSQLite.podspec
+++ b/packages/react-native-nitro-sqlite/RNNitroSQLite.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
     "cpp/**/*.{h,hpp,c,cpp}"
   ]
 
-  s.pod_target_xcconfig = {
+  xcconfig = {
     :GCC_PREPROCESSOR_DEFINITIONS => "HAVE_FULLFSYNC=1",
     :WARNING_CFLAGS => "-Wno-shorten-64-to-32 -Wno-comma -Wno-unreachable-code -Wno-conditional-uninitialized -Wno-deprecated-declarations",
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20',
@@ -49,12 +49,14 @@ Pod::Spec.new do |s|
   optimizedCflags = '$(inherited) -DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1 -DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1 -DSQLITE_MAX_EXPR_DEPTH=0 -DSQLITE_OMIT_DEPRECATED=1 -DSQLITE_OMIT_PROGRESS_CALLBACK=1 -DSQLITE_OMIT_SHARED_CACHE=1 -DSQLITE_USE_ALLOCA=1'
 
   if performance_mode == 1
-    log_message.call("Thread unsafe (1) performance mode enabled. Use only transactions! 🚀🚀")
-    s.pod_target_xcconfig["OTHER_CFLAGS"] = optimizedCflags + ' -DSQLITE_THREADSAFE=0 '
+    Pod::UI.puts "Thread unsafe (1) performance mode enabled. Use only transactions! 🚀🚀"
+    xcconfig["OTHER_CFLAGS"] = optimizedCflags + ' -DSQLITE_THREADSAFE=0 '
   elsif performance_mode == 2
-    log_message.call("Thread safe (2) performance mode enabled 🚀")
-    s.pod_target_xcconfig["OTHER_CFLAGS"] = optimizedCflags + ' -DSQLITE_THREADSAFE=1 '
+    Pod::UI.puts "Thread safe (2) performance mode enabled 🚀"
+    xcconfig["OTHER_CFLAGS"] = optimizedCflags + ' -DSQLITE_THREADSAFE=1 '
   end
+
+  s.pod_target_xcconfig = xcconfig
 
   if ENV['NITRO_SQLITE_USE_PHONE_VERSION'] == '1' then
     s.exclude_files = "cpp/sqlite/sqlite3.c", "cpp/sqlite/sqlite3.h"


### PR DESCRIPTION
## Summary

- compare `performance_mode` using its integer type
- write performance flags through `s.pod_target_xcconfig`
- make the two performance modes mutually exclusive

## Root cause

`performance_mode` is initialized as an integer but was compared with string values, so neither branch executed. This also masked references to an undefined `xcconfig` variable inside both branches.

## Impact

The configured default performance mode now applies the intended SQLite compiler options, including `SQLITE_THREADSAFE=0` for mode 1.

## Validation

- `ruby -c packages/react-native-nitro-sqlite/RNNitroSQLite.podspec`
- `git diff --check`
