### PR TITLE
fix: correct SQLite column metadata types

### DIFF
--- a/example/tests/unit/specs/operations/execute.spec.ts
+++ b/example/tests/unit/specs/operations/execute.spec.ts
@@ -1,6 +1,29 @@
 import { chance, expect, isNitroSQLiteError } from '@tests/unit/common'
 import { describe, it } from '@tests/TestApi'
 import { createArrayBufferTestDb, testDb } from '@tests/db'
+import type { ColumnType } from 'react-native-nitro-sqlite'
+
+const metadataQuery = `
+  SELECT
+    boolean_value,
+    float_value,
+    integer_value,
+    text_value,
+    blob_value,
+    NULL AS null_value
+  FROM ColumnMetadata
+`
+
+function expectColumnMetadata(
+  metadata: Record<string, { type: ColumnType }> | undefined,
+) {
+  expect(metadata?.boolean_value?.type).toBe(0)
+  expect(metadata?.float_value?.type).toBe(1)
+  expect(metadata?.integer_value?.type).toBe(2)
+  expect(metadata?.text_value?.type).toBe(3)
+  expect(metadata?.blob_value?.type).toBe(4)
+  expect(metadata?.null_value?.type).toBe(5)
+}
 
 export default function registerExecuteUnitTests() {
   describe('execute', () => {
@@ -134,6 +157,28 @@ export default function registerExecuteUnitTests() {
             networth,
           },
         ])
+      })
+    })
+
+    describe('metadata', () => {
+      it('maps declared column types for execute', () => {
+        testDb.execute('DROP TABLE IF EXISTS ColumnMetadata')
+        testDb.execute(
+          'CREATE TABLE ColumnMetadata (boolean_value BOOLEAN, float_value FLOAT, integer_value INTEGER, text_value TEXT, blob_value BLOB)',
+        )
+
+        expectColumnMetadata(testDb.execute(metadataQuery).metadata)
+      })
+
+      it('maps declared column types for executeAsync', async () => {
+        await testDb.executeAsync('DROP TABLE IF EXISTS ColumnMetadata')
+        await testDb.executeAsync(
+          'CREATE TABLE ColumnMetadata (boolean_value BOOLEAN, float_value FLOAT, integer_value INTEGER, text_value TEXT, blob_value BLOB)',
+        )
+
+        expectColumnMetadata(
+          (await testDb.executeAsync(metadataQuery)).metadata,
+        )
       })
     })
 

--- a/packages/react-native-nitro-sqlite/cpp/types.hpp
+++ b/packages/react-native-nitro-sqlite/cpp/types.hpp
@@ -25,15 +25,15 @@ struct SQLiteOperationResult {
 inline ColumnType mapSQLiteTypeToColumnType(const char* type) {
   if (type == NULL) {
     return ColumnType::NULL_VALUE;
-  } else if (strcmp(type, "BOOLEAN")) {
+  } else if (strcmp(type, "BOOLEAN") == 0) {
     return ColumnType::BOOLEAN;
-  } else if (strcmp(type, "FLOAT")) {
+  } else if (strcmp(type, "FLOAT") == 0) {
     return ColumnType::NUMBER;
-  } else if (strcmp(type, "INTEGER")) {
+  } else if (strcmp(type, "INTEGER") == 0) {
     return ColumnType::INT64;
-  } else if (strcmp(type, "TEXT")) {
+  } else if (strcmp(type, "TEXT") == 0) {
     return ColumnType::TEXT;
-  } else if (strcmp(type, "BLOB")) {
+  } else if (strcmp(type, "BLOB") == 0) {
     return ColumnType::ARRAY_BUFFER;
   } else {
     return ColumnType::NULL_VALUE;


### PR DESCRIPTION
## Summary

- compare SQLite declared types with `strcmp(...) == 0` instead of treating non-equality as a match
- restore metadata mapping for `BOOLEAN`, `FLOAT`, `INTEGER`, `TEXT`, `BLOB`, and undeclared expressions
- add real-database regression coverage for both `execute()` and `executeAsync()`

This preserves the current exact-declaration contract. Affinity aliases such as `REAL`, `DOUBLE`, `VARCHAR(...)`, and `INT` remain outside the existing mapping and continue to fall back to `NULL_VALUE`.

## Verification

- iOS react-native-harness focused RED before fix: 2 metadata tests failed (`BOOLEAN` reported as `NUMBER`)
- iOS react-native-harness focused GREEN after fix: 2 passed
- iOS react-native-harness full unit file: 34 passed
- `bun run typecheck` (all three workspaces)
- Prettier check for the harness test
- clang-format dry run for `types.hpp`
- `git diff --check`

Closes #305.