### PR TITLE
fix(android): support Gradle configuration cache

### DIFF
--- a/packages/react-native-nitro-sqlite/android/build.gradle
+++ b/packages/react-native-nitro-sqlite/android/build.gradle
@@ -51,6 +51,14 @@ def supportsNamespace() {
   return (major == 7 && minor >= 3) || major >= 8
 }
 
+def resolveNodePackageJson(packageName) {
+  def packageJsonPath = providers.exec {
+    workingDir(rootDir)
+    commandLine("node", "--print", "require.resolve('${packageName}/package.json')")
+  }.standardOutput.asText.get().trim()
+  return file(packageJsonPath)
+}
+
 def resolveReactNativeDirectory() {
   def reactNativeLocation = safeAppExtGet("REACT_NATIVE_NODE_MODULES_DIR", null)
   if (reactNativeLocation != null) {
@@ -58,7 +66,7 @@ def resolveReactNativeDirectory() {
   }
 
   // Fallback to node resolver for custom directory structures like monorepos.
-  def reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim())
+  def reactNativePackage = resolveNodePackageJson("react-native")
   if (reactNativePackage.exists()) {
     return reactNativePackage.parentFile
   }
@@ -80,8 +88,8 @@ def NITRO_SQLITE_VEC_ENABLED = (rootProject.findProperty('nitroSqliteVec') ?: 'f
 def NITRO_SQLITE_VEC_CPP_DIR = ''
 if (NITRO_SQLITE_VEC_ENABLED) {
   try {
-    def vecPkgJson = ["node", "--print", "require.resolve('react-native-nitro-sqlite-vec/package.json')"].execute(null, rootDir).text.trim()
-    NITRO_SQLITE_VEC_CPP_DIR = new File(new File(vecPkgJson).parentFile, "cpp").absolutePath
+    def vecPkgJson = resolveNodePackageJson("react-native-nitro-sqlite-vec")
+    NITRO_SQLITE_VEC_CPP_DIR = new File(vecPkgJson.parentFile, "cpp").absolutePath
   } catch (Exception e) {
     throw new GradleException("[react-native-nitro-sqlite] nitroSqliteVec=true but 'react-native-nitro-sqlite-vec' could not be resolved. Install it in your app (e.g. `bun add react-native-nitro-sqlite-vec`).")
   }


### PR DESCRIPTION
## Summary

Fixes #241.

- replace Groovy `Process.execute()` package resolution with Gradle’s configuration-cache-aware `providers.exec()`
- track both React Native and optional `react-native-nitro-sqlite-vec` resolver outputs as configuration inputs
- preserve the existing monorepo fallback, explicit `REACT_NATIVE_NODE_MODULES_DIR` override, and vec resolution error

Gradle documents `providers.exec { ... }.standardOutput.asText.get()` as the supported API when configuration-time process output is required: https://docs.gradle.org/current/userguide/configuration_cache_requirements.html#config_cache:requirements:external_processes

## Test plan

### Red

`./gradlew :react-native-nitro-sqlite:tasks --configuration-cache --no-daemon` failed to store the cache with two problems:

1. external `node` process resolving `react-native/package.json`
2. external `node` process resolving `react-native-nitro-sqlite-vec/package.json`

### Green

- the same task stored the configuration cache successfully, then the next invocation reported `Reusing configuration cache`
- `:react-native-nitro-sqlite:assembleDebug --configuration-cache` completed the Android/CMake build, stored the cache, and a subsequent invocation reported `Configuration cache entry reused`
- `bun typecheck`
- `bun sqlite build`
- `bun lint`
- `git diff --check`

### Existing test-infrastructure issue

`bun sqlite test` stops in Jest configuration before collecting tests because the current RN 0.85 dependency moved the preset from `react-native` to `@react-native/jest-preset`. This is reproducible on unchanged `main` and is unrelated to the Gradle-only diff.