### PR TITLE
fix: enable SQLite RTree extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,8 @@ NITRO_SQLITE_USE_PHONE_VERSION=1 npx pod-install
 
 ## Compile-time options (e.g. FTS5, Geopoly)
 
+The bundled SQLite build enables the RTree extension by default on iOS and Android.
+
 **iOS** — in your app’s `ios/Podfile`, in a `post_install` block:
 
 ```ruby

--- a/example/tests/unit/specs/operations/execute.spec.ts
+++ b/example/tests/unit/specs/operations/execute.spec.ts
@@ -137,6 +137,37 @@ export default function registerExecuteUnitTests() {
       })
     })
 
+    describe('SQLite extensions', () => {
+      it('creates and queries an RTree virtual table', () => {
+        testDb.execute('DROP TABLE IF EXISTS SpatialIndex')
+
+        try {
+          testDb.execute(`
+            CREATE VIRTUAL TABLE SpatialIndex USING rtree(
+              id,
+              minX, maxX,
+              minY, maxY
+            )
+          `)
+          testDb.execute(
+            'INSERT INTO SpatialIndex (id, minX, maxX, minY, maxY) VALUES (?, ?, ?, ?, ?)',
+            [1, 10, 20, 30, 40],
+          )
+
+          const result = testDb.execute(
+            'SELECT id, minX, maxX, minY, maxY FROM SpatialIndex WHERE minX <= ? AND maxX >= ?',
+            [15, 15],
+          )
+
+          expect(result.results).toEqual([
+            { id: 1, minX: 10, maxX: 20, minY: 30, maxY: 40 },
+          ])
+        } finally {
+          testDb.execute('DROP TABLE IF EXISTS SpatialIndex')
+        }
+      })
+    })
+
     describe('ArrayBuffer support', () => {
       describe('execute', () => {
         it('stores and reads ArrayBuffer values from BLOB columns', () => {

--- a/packages/react-native-nitro-sqlite/RNNitroSQLite.podspec
+++ b/packages/react-native-nitro-sqlite/RNNitroSQLite.podspec
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
     'CLANG_CXX_LIBRARY' => 'libc++',
     'DEFINES_MODULE' => 'YES',
     "HEADER_SEARCH_PATHS" => "\"${PODS_ROOT}/RCT-Folly\"" + (nitro_sqlite_vec ? " \"#{nitro_sqlite_vec_cpp}\"" : ""),
-    "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) FOLLY_NO_CONFIG FOLLY_CFG_NO_COROUTINES" + (nitro_sqlite_vec ? " NITRO_SQLITE_VEC=1" : ""),
+    "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) FOLLY_NO_CONFIG FOLLY_CFG_NO_COROUTINES SQLITE_ENABLE_RTREE=1" + (nitro_sqlite_vec ? " NITRO_SQLITE_VEC=1" : ""),
     "OTHER_CPLUSPLUSFLAGS" => folly_compiler_flags,
     "OTHER_CFLAGS" => other_cflags,
   }

--- a/packages/react-native-nitro-sqlite/android/CMakeLists.txt
+++ b/packages/react-native-nitro-sqlite/android/CMakeLists.txt
@@ -5,6 +5,7 @@ set (CMAKE_VERBOSE_MAKEFILE ON)
 set (CMAKE_CXX_STANDARD 20)
 
 add_definitions(
+  -DSQLITE_ENABLE_RTREE=1
   ${SQLITE_FLAGS}
 )
 


### PR DESCRIPTION
## Summary

- enable `SQLITE_ENABLE_RTREE` for the bundled SQLite build on Android and iOS
- add a React Native harness regression test that creates, inserts into, and queries an RTree virtual table
- document that RTree is available by default

Closes #218.

## Verification

- `bun typecheck`
- `bun lint`
- `bun sqlite build`
- `bunx prettier --check README.md example/tests/unit/specs/operations/execute.spec.ts`
- `ruby -c packages/react-native-nitro-sqlite/RNNitroSQLite.podspec`
- Android `:react-native-nitro-sqlite:assembleDebug` for all configured ABIs
- iOS `RNNitroSQLite` target build on iOS Simulator
- iOS harness: 33 unit tests, 1 TypeORM test, and 35 sqlite-vec tests passed
- bundled `sqlite3.c` native probe reproduced `no such module: rtree` without the flag and passed with the flag

## Existing test-runner limitation

`bun sqlite test --runInBand` currently exits during Jest configuration because React Native 0.85 moved its Jest preset to `@react-native/jest-preset`. The native harness suites above exercise the changed behavior successfully.