### PR TITLE
fix: reject duplicate database opens

### DIFF
--- a/example/tests/unit/specs/DatabaseQueue.spec.ts
+++ b/example/tests/unit/specs/DatabaseQueue.spec.ts
@@ -7,11 +7,30 @@ import {
 } from '@tests/unit/common'
 import { describe, it } from '@tests/TestApi'
 import { testDb, testDbQueue } from '@tests/db'
-import type { BatchQueryCommand } from 'react-native-nitro-sqlite'
+import {
+  NitroSQLite,
+  NitroSQLiteError,
+  open,
+  type BatchQueryCommand,
+} from 'react-native-nitro-sqlite'
 
 const TEST_QUERY = 'SELECT * FROM [User];'
 
 const TEST_BATCH_COMMANDS: BatchQueryCommand[] = [{ query: TEST_QUERY }]
+
+function dropDatabaseIfExists(dbName: string, location?: string) {
+  try {
+    NitroSQLite.native.drop(dbName, location)
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes('Database file not found')
+    ) {
+      return
+    }
+    throw error
+  }
+}
 
 export default function registerDatabaseQueueUnitTests() {
   describe('Database Queue', () => {
@@ -176,6 +195,77 @@ export default function registerDatabaseQueueUnitTests() {
         } else {
           throw new Error(TEST_ERROR_CODES.EXPECT_NITRO_SQLITE_ERROR)
         }
+      }
+    })
+
+    it('rejects a duplicate session open without replacing the original connection', () => {
+      const dbName = 'duplicate-session-open'
+      dropDatabaseIfExists(dbName)
+      dropDatabaseIfExists(dbName, '..')
+
+      const db = open({ name: dbName })
+
+      try {
+        db.execute('CREATE TABLE ConnectionMarker (value TEXT NOT NULL)')
+        db.execute('INSERT INTO ConnectionMarker (value) VALUES (?)', [
+          'original',
+        ])
+
+        let duplicateError: unknown
+        try {
+          open({ name: dbName, location: '..' })
+        } catch (error) {
+          duplicateError = error
+        }
+
+        expect(duplicateError).toBeInstanceOf(NitroSQLiteError)
+        expect((duplicateError as Error).message).toContain('already open')
+        expect(
+          db.execute<{ value: string }>('SELECT value FROM ConnectionMarker')
+            .results,
+        ).toEqual([{ value: 'original' }])
+      } finally {
+        db.close()
+        dropDatabaseIfExists(dbName)
+        dropDatabaseIfExists(dbName, '..')
+      }
+    })
+
+    it('rejects duplicate direct native opens', () => {
+      const dbName = 'duplicate-native-open'
+      dropDatabaseIfExists(dbName)
+
+      NitroSQLite.native.open(dbName)
+
+      try {
+        NitroSQLite.execute(
+          dbName,
+          'CREATE TABLE ConnectionMarker (value TEXT NOT NULL)',
+        )
+        NitroSQLite.execute(
+          dbName,
+          'INSERT INTO ConnectionMarker (value) VALUES (?)',
+          ['original'],
+        )
+
+        let duplicateError: unknown
+        try {
+          NitroSQLite.native.open(dbName)
+        } catch (error) {
+          duplicateError = error
+        }
+
+        expect(duplicateError).toBeInstanceOf(Error)
+        expect((duplicateError as Error).message).toContain('already open')
+        expect(
+          NitroSQLite.execute<{ value: string }>(
+            dbName,
+            'SELECT value FROM ConnectionMarker',
+          ).results,
+        ).toEqual([{ value: 'original' }])
+      } finally {
+        NitroSQLite.native.close(dbName)
+        dropDatabaseIfExists(dbName)
       }
     })
   })

--- a/packages/react-native-nitro-sqlite/cpp/NitroSQLiteException.hpp
+++ b/packages/react-native-nitro-sqlite/cpp/NitroSQLiteException.hpp
@@ -46,6 +46,11 @@ public:
     return this->_exceptionString.c_str();
   }
 
+  static NitroSQLiteException DatabaseAlreadyOpen(const std::string& dbName) {
+    return NitroSQLiteException(NitroSQLiteExceptionType::DatabaseCannotBeOpened,
+                                "Database " + dbName + " is already open. There is already a connection to the database.");
+  }
+
   static NitroSQLiteException DatabaseNotOpen(const std::string& dbName) {
     return NitroSQLiteException(NitroSQLiteExceptionType::UnableToAttachToDatabase, dbName + " is not open");
   }

--- a/packages/react-native-nitro-sqlite/cpp/operations.cpp
+++ b/packages/react-native-nitro-sqlite/cpp/operations.cpp
@@ -32,6 +32,10 @@ static constexpr double kInt64UpperBoundAsDouble = -kInt64MinAsDouble;
 std::map<std::string, sqlite3*> dbMap = std::map<std::string, sqlite3*>();
 
 void sqliteOpenDb(const std::string& dbName, const std::string& docPath) {
+  if (dbMap.contains(dbName)) {
+    throw NitroSQLiteException::DatabaseAlreadyOpen(dbName);
+  }
+
 #ifdef NITRO_SQLITE_VEC
   // Register before opening so the connection exposes vec0 + vec_*.
   margelo::rnnitrosqlitevec::registerVectorExtensions();
@@ -41,15 +45,20 @@ void sqliteOpenDb(const std::string& dbName, const std::string& docPath) {
 
   int sqlOpenFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX;
 
-  sqlite3* db;
-  int exit = 0;
-  exit = sqlite3_open_v2(dbPath.c_str(), &db, sqlOpenFlags, nullptr);
+  sqlite3* rawDatabase = nullptr;
+  const int openStatus = sqlite3_open_v2(dbPath.c_str(), &rawDatabase, sqlOpenFlags, nullptr);
+  std::unique_ptr<sqlite3, decltype(&sqlite3_close_v2)> database(rawDatabase, sqlite3_close_v2);
 
-  if (exit != SQLITE_OK) {
-    throw NitroSQLiteException(NitroSQLiteExceptionType::DatabaseCannotBeOpened, sqlite3_errmsg(db));
-  } else {
-    dbMap[dbName] = db;
+  if (openStatus != SQLITE_OK) {
+    const std::string errorMessage = rawDatabase == nullptr ? sqlite3_errstr(openStatus) : sqlite3_errmsg(rawDatabase);
+    throw NitroSQLiteException(NitroSQLiteExceptionType::DatabaseCannotBeOpened, errorMessage);
   }
+
+  const bool inserted = dbMap.emplace(dbName, database.get()).second;
+  if (!inserted) {
+    throw NitroSQLiteException::DatabaseAlreadyOpen(dbName);
+  }
+  database.release();
 }
 
 void sqliteCloseDb(const std::string& dbName) {


### PR DESCRIPTION
## Summary

- reject duplicate database names in the native registry before calling `sqlite3_open_v2`
- preserve the existing connection when a session tries to reopen the same name from another location
- keep newly opened handles under RAII ownership until registry insertion succeeds
- close partial SQLite handles when `sqlite3_open_v2` fails
- cover both the public session API and direct `NitroSQLite.native.open()` path

The current connection identity remains `dbName`. Opening the same filename from a different `location` is therefore rejected explicitly instead of silently rerouting the first connection.

Closes #306.

## TDD evidence

**RED on `main`:**

- the session duplicate test threw from the JS queue only after native state had already been overwritten; the original connection then failed with `no such table: ConnectionMarker`
- the direct native duplicate test received no error

**GREEN:** both focused tests pass against the rebuilt iOS app, and the original connection still returns its marker row.

## Verification

- focused iOS harness: 2 duplicate-open tests passed
- full iOS unit harness: 34/34 passed
- iOS TypeORM harness: 1/1 passed
- iOS sqlite-vec harness: 35/35 passed
- iOS example app build: succeeded
- Android `:react-native-nitro-sqlite:assembleDebug`: succeeded for all configured ABIs
- `bun typecheck`
- `bun lint`
- `bun sqlite build`
- Prettier and clang-format checks for changed files
- `git diff --check`
- no dependency or lockfile changes

## Existing test-runner limitation

`bun sqlite test --runInBand` exits during Jest configuration before collecting tests because React Native 0.85 moved its preset to `@react-native/jest-preset`. This is reproducible on unchanged `main`; the native harness suites above exercise the changed behavior.