### PR TITLE
perf: materialize query results once

### DIFF
--- a/example/tests/unit/specs/operations/execute.spec.ts
+++ b/example/tests/unit/specs/operations/execute.spec.ts
@@ -1,9 +1,122 @@
 import { chance, expect, isNitroSQLiteError } from '@tests/unit/common'
 import { describe, it } from '@tests/TestApi'
 import { createArrayBufferTestDb, testDb } from '@tests/db'
+import { open } from 'react-native-nitro-sqlite'
+import { buildJSQueryResult } from '../../../../../packages/react-native-nitro-sqlite/src/operations/execute'
+import type { NitroSQLiteQueryResult } from '../../../../../packages/react-native-nitro-sqlite/src/specs/NitroSQLiteQueryResult.nitro'
+
+const QUERY_RESULT_SIZES = [60, 1_000, 10_000]
+
+function createQueryResultTestDb(name: string) {
+  const db = open({ name })
+
+  db.execute('DROP TABLE IF EXISTS QueryResultRows;')
+  db.execute(
+    'CREATE TABLE QueryResultRows (id INTEGER PRIMARY KEY, name TEXT NOT NULL, nullable TEXT, payload BLOB) STRICT;',
+  )
+  db.execute(`
+    WITH RECURSIVE counter(id) AS (
+      SELECT 1
+      UNION ALL
+      SELECT id + 1 FROM counter WHERE id < 10000
+    )
+    INSERT INTO QueryResultRows (id, name, nullable, payload)
+    SELECT
+      id,
+      'row-' || id,
+      CASE WHEN id = 1 THEN NULL ELSE 'value-' || id END,
+      CASE WHEN id = 1 THEN zeroblob(4) ELSE NULL END
+    FROM counter;
+  `)
+
+  return db
+}
+
+function expectQueryResultRows(
+  result: ReturnType<typeof testDb.execute>,
+  size: number,
+) {
+  expect(result.rows._array).toHaveLength(size)
+  expect(result.rows.length).toBe(size)
+
+  for (let index = 0; index < size; index++) {
+    expect(result.rows.item(index)).toBe(result.rows._array[index])
+  }
+
+  expect(result.rows.item(size)).toBe(undefined)
+  expect(result.rows.item(0)?.id).toBe(1)
+  expect(result.rows.item(size - 1)?.id).toBe(size)
+  expect(result.rows.item(0)?.nullable).toBe(null)
+
+  const payload = result.rows.item(0)?.payload
+  expect(payload).toBeInstanceOf(ArrayBuffer)
+  expect(Array.from(new Uint8Array(payload as ArrayBuffer))).toEqual([
+    0, 0, 0, 0,
+  ])
+}
 
 export default function registerExecuteUnitTests() {
   describe('execute', () => {
+    it('materializes native query results once', () => {
+      const sourceRows = [
+        { id: 1, nullable: null },
+        { id: 2, nullable: 'value' },
+      ]
+      let resultsReads = 0
+      const nativeResult = {
+        rowsAffected: sourceRows.length,
+        get results() {
+          resultsReads += 1
+          return [...sourceRows]
+        },
+      } as unknown as NitroSQLiteQueryResult
+
+      const result = buildJSQueryResult(nativeResult)
+
+      expect(result.rows._array).toEqual(sourceRows)
+      expect(result.rows.length).toBe(sourceRows.length)
+      expect(result.rows.item(0)).toEqual(sourceRows[0])
+      expect(result.rows.item(1)).toEqual(sourceRows[1])
+      expect(result.rows.item(sourceRows.length)).toBe(undefined)
+      expect(resultsReads).toBe(1)
+    })
+
+    it('preserves row access for large synchronous results', () => {
+      const db = createQueryResultTestDb('query_result_rows_sync')
+
+      try {
+        for (const size of QUERY_RESULT_SIZES) {
+          const result = db.execute(
+            'SELECT * FROM QueryResultRows ORDER BY id LIMIT ?',
+            [size],
+          )
+
+          expectQueryResultRows(result, size)
+        }
+      } finally {
+        db.close()
+        db.delete()
+      }
+    })
+
+    it('preserves row access for large asynchronous results', async () => {
+      const db = createQueryResultTestDb('query_result_rows_async')
+
+      try {
+        for (const size of QUERY_RESULT_SIZES) {
+          const result = await db.executeAsync(
+            'SELECT * FROM QueryResultRows ORDER BY id LIMIT ?',
+            [size],
+          )
+
+          expectQueryResultRows(result, size)
+        }
+      } finally {
+        db.close()
+        db.delete()
+      }
+    })
+
     describe('Insert', () => {
       it('Insert', () => {
         const id = chance.integer()

--- a/packages/react-native-nitro-sqlite/src/operations/execute.ts
+++ b/packages/react-native-nitro-sqlite/src/operations/execute.ts
@@ -33,15 +33,16 @@ export async function executeAsync<Row extends QueryResultRow = never>(
   }
 }
 
-function buildJSQueryResult<Row extends QueryResultRow = never>(
+export function buildJSQueryResult<Row extends QueryResultRow = never>(
   result: NitroSQLiteQueryResult,
 ): QueryResult<Row> {
   const resultWithRows = result as QueryResult<Row>
+  const results = result.results as Row[]
 
   resultWithRows.rows = {
-    _array: result.results as Row[],
-    length: result.results.length,
-    item: (idx: number) => result.results[idx] as Row | undefined,
+    _array: results,
+    length: results.length,
+    item: (idx: number) => results[idx],
   }
 
   return resultWithRows


### PR DESCRIPTION
## Summary

- materialize the hybrid `results` getter once when building the JS-compatible rows object
- make `_array`, `length`, and `item(index)` share that single materialized array
- cover getter reads plus 60, 1,000, and 10,000-row sync/async access, including NULL, BLOB, and out-of-range behavior

Fixes #310.

## Why

`results` is a HybridObject getter that returns the native result vector by value. The previous `rows.item(index)` closure evaluated that getter for every item, so traversing N rows requested N additional full result vectors. Caching the first materialization preserves the public result shape while removing the quadratic copy pattern.

## Benchmark

Synthetic getter-copy benchmark using Bun 1.3.14, six-column rows, one warm-up plus 20 measured iterations. The getter conservatively returns a shallow array copy; timings include wrapper construction and the named consumer.

| Rows | Consumer | Main median / p95 | This PR median / p95 | Getter reads |
| ---: | --- | ---: | ---: | ---: |
| 60 | full `item()` traversal | 0.0112 / 0.0150 ms | 0.000709 / 0.00504 ms | 62 → 1 |
| 1,000 | full `item()` traversal | 0.579 / 1.002 ms | 0.00250 / 0.00313 ms | 1,002 → 1 |
| 10,000 | full `item()` traversal | 30.014 / 32.130 ms | 0.01396 / 0.01504 ms | 10,002 → 1 |

For direct `_array` and `length` consumers, getter reads drop from 2 to 1 at every size. At 10,000 rows their median wrapper-plus-access time drops from about 0.014 ms to 0.006–0.008 ms in the same conservative benchmark.

The committed real-device harness coverage also traverses all items for 60, 1,000, and 10,000 rows through both `execute` and `executeAsync`.

## Verification

- `bun typecheck`
- `bun lint`
- `bun sqlite build`
- iOS simulator, Debug/Hermes: unit 35/35, TypeORM 1/1, sqlite-vec 35/35
- Android API 35 emulator, Debug/Hermes: unit 35/35, TypeORM 1/1, sqlite-vec 35/35
- Android `assembleDebug` succeeded across all configured ABIs
- regression test verified red on `main` (5 getter reads for two rows) and green on this branch (1 read)

`bun sqlite test --runInBand` is currently blocked before test discovery by the repository's React Native 0.85 preset migration (`react-native` now requires `@react-native/jest-preset`). The real React Native harness suites above pass on both platforms.
