### PR TITLE
feat(ios): add option to store databases in Library/Application Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,23 @@ nitroSqliteFlags="-DSQLITE_ENABLE_FTS5=1"
 
 To put the database in an app group (e.g. for extensions), set `RNNitroSQLite_AppGroup` in your `Info.plist` to the app group ID and add the App Groups capability in Xcode.
 
+## Database location (iOS)
+
+By default, databases are stored in the app's **Documents** directory. If your app enables file sharing (`UIFileSharingEnabled` + `LSSupportsOpeningDocumentsInPlace`), that directory — including your raw database and its `-wal`/`-shm` journal files — becomes visible to users in the Files app, where they can be shared, modified, or deleted from outside your app.
+
+To store databases in `Library/Application Support` instead (persistent, backed up, and never user-visible), set `RNNitroSQLite_DatabaseLocation` in your `Info.plist`:
+
+```xml
+<key>RNNitroSQLite_DatabaseLocation</key>
+<string>ApplicationSupport</string>
+```
+
+Supported values are `Documents` (the default) and `ApplicationSupport`.
+
+Databases created while the app was still using the Documents directory are automatically moved to `Library/Application Support` the first time they are opened after enabling this option, so existing users keep their data. If you later remove the option, databases already moved to `Library/Application Support` are **not** moved back.
+
+This option has no effect when `RNNitroSQLite_AppGroup` is set, since app group databases live in the shared container.
+
 ---
 
 # Exports

--- a/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.cpp
+++ b/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.cpp
@@ -6,6 +6,7 @@
 #include "macros.hpp"
 #include "operations.hpp"
 #include "sqliteExecuteBatch.hpp"
+#include <filesystem>
 #include <iostream>
 #include <map>
 #include <optional>
@@ -65,8 +66,76 @@ const std::string getDocPath(const std::optional<std::string>& location) {
   return tempDocPath;
 }
 
+// Moves a database (together with its -wal/-shm journal files) out of the directory a previous
+// app version stored it in. Committed-but-uncheckpointed writes live in the -wal file and SQLite
+// only replays it when it sits next to its database, so the set must never be separated: the
+// whole set is copied before any original is deleted, and if anything fails the intact originals
+// stay in place (the caller then keeps opening the database there) and the migration retries on
+// the next open.
+static void migrateDatabase(const std::string& dbName, const std::filesystem::path& fromDirectory,
+                            const std::filesystem::path& toDirectory) {
+  namespace fs = std::filesystem;
+  const std::string files[] = {dbName, dbName + "-wal", dbName + "-shm"};
+  std::error_code ec;
+
+  if (!fs::exists(fromDirectory / dbName, ec)) {
+    // Nothing to migrate. A previous run may have been interrupted after copying the set but
+    // before removing the journal files, so sweep any leftovers out of the old directory.
+    fs::remove(fromDirectory / (dbName + "-wal"), ec);
+    fs::remove(fromDirectory / (dbName + "-shm"), ec);
+    return;
+  }
+
+  // A database in the old directory means an older app version was writing there, so it is the
+  // live copy. Remove whatever sits at the destination (e.g. after a downgrade and re-upgrade)
+  // so a -wal from one database generation is never replayed into a database from another.
+  for (const auto& file : files) {
+    fs::remove(toDirectory / file, ec);
+  }
+
+  fs::create_directories(toDirectory, ec);
+  for (const auto& file : files) {
+    if (!fs::exists(fromDirectory / file, ec)) {
+      continue;
+    }
+
+    if (!fs::copy_file(fromDirectory / file, toDirectory / file, ec) || ec) {
+      LOGW("Failed to migrate database file %s: %s", file.c_str(), ec.message().c_str());
+      return;
+    }
+  }
+
+  // The database file is deleted first, and the journals only once that succeeds: if the
+  // database cannot be removed, the caller keeps opening it from the old directory, so its -wal
+  // must stay next to it or committed writes would be lost. An interruption after the first
+  // delete can only leave journal files behind, which the sweep above removes on the next open.
+  if (!fs::remove(fromDirectory / dbName, ec) || ec) {
+    LOGW("Failed to remove migrated database %s from its old location: %s", dbName.c_str(), ec.message().c_str());
+    return;
+  }
+  fs::remove(fromDirectory / (dbName + "-wal"), ec);
+  fs::remove(fromDirectory / (dbName + "-shm"), ec);
+}
+
 void HybridNitroSQLite::open(const std::string& dbName, const std::optional<std::string>& location) {
-  const auto docPath = getDocPath(location);
+  auto docPath = getDocPath(location);
+
+  if (!migrationDocPath.empty()) {
+    std::string oldDocPath = migrationDocPath;
+    if (location) {
+      oldDocPath = oldDocPath + "/" + *location;
+    }
+
+    migrateDatabase(dbName, oldDocPath, docPath);
+
+    // If the database could not be moved out of its old directory, keep opening it there rather
+    // than creating a fresh empty one; the migration retries on the next open.
+    std::error_code ec;
+    if (std::filesystem::exists(std::filesystem::path(oldDocPath) / dbName, ec)) {
+      docPath = oldDocPath;
+    }
+  }
+
   sqliteOpenDb(dbName, docPath);
 }
 

--- a/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.hpp
+++ b/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.hpp
@@ -14,6 +14,10 @@ public:
 
 public:
   static std::string docPath;
+  // Directory databases were stored in by previous app versions, when the platform layer has
+  // relocated docPath (e.g. iOS with RNNitroSQLite_DatabaseLocation set to "ApplicationSupport").
+  // When non-empty, each database found there is moved to docPath as it is opened.
+  static std::string migrationDocPath;
 
 public:
   // Methods
@@ -43,5 +47,6 @@ public:
 };
 
 inline std::string HybridNitroSQLite::docPath = "";
+inline std::string HybridNitroSQLite::migrationDocPath = "";
 
 } // namespace margelo::nitro::rnnitrosqlite

--- a/packages/react-native-nitro-sqlite/ios/OnLoad.mm
+++ b/packages/react-native-nitro-sqlite/ios/OnLoad.mm
@@ -30,9 +30,32 @@ using namespace margelo::nitro::rnnitrosqlite;
 
     documentPath = [storeUrl path];
   } else {
-    // Get iOS app's document directory (to safely store database .sqlite3 file)
-    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, true);
-    documentPath = [paths objectAtIndex:0];
+    NSString *databaseLocation = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RNNitroSQLite_DatabaseLocation"];
+
+    if ([databaseLocation isEqualToString:@"ApplicationSupport"]) {
+      // Library/Application Support is persistent, backed up, and never exposed to the user
+      // via the Files app (unlike the Documents directory, which becomes user-visible when
+      // the app enables file sharing).
+      NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, true);
+      documentPath = [paths objectAtIndex:0];
+
+      NSFileManager *fileManager = [NSFileManager defaultManager];
+      if (![fileManager fileExistsAtPath:documentPath]) {
+        [fileManager createDirectoryAtPath:documentPath withIntermediateDirectories:YES attributes:nil error:nil];
+      }
+
+      // Databases created before this option was enabled still live in Documents; each one is
+      // moved over when it is opened (see HybridNitroSQLite::open).
+      NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, true) objectAtIndex:0];
+      HybridNitroSQLite::migrationDocPath = [documentsDirectory UTF8String];
+    } else {
+      if (databaseLocation != nil && ![databaseLocation isEqualToString:@"Documents"]) {
+        NSLog(@"Invalid RNNitroSQLite_DatabaseLocation value provided (%@). Supported values are \"Documents\" and \"ApplicationSupport\". Falling back to \"Documents\".", databaseLocation);
+      }
+      // Get iOS app's document directory (to safely store database .sqlite3 file)
+      NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, true);
+      documentPath = [paths objectAtIndex:0];
+    }
   }
 
   HybridNitroSQLite::docPath = [documentPath UTF8String];


### PR DESCRIPTION
## Motivation

Fixes https://github.com/margelo/react-native-nitro-sqlite/issues/289.

On iOS (without an App Group), databases are stored in the app's **Documents** directory. When an app enables file sharing (`UIFileSharingEnabled` + `LSSupportsOpeningDocumentsInPlace`), Documents becomes visible to users in the Files app — including the raw SQLite database and its `-wal`/`-shm` journals, which can then be shared, modified, or deleted from outside the app. Apple's [File System Programming Guide](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html) recommends `Library/Application Support` for app-internal data files: it is persistent, backed up, and never user-visible.

We hit this in production at Expensify and have been shipping this behavior as a `patch-package` patch since [Expensify/App#96531](https://github.com/Expensify/App/pull/96531); this PR upstreams it in a generalized, opt-in form.

## What this does

Adds a new `Info.plist` key, following the existing `RNNitroSQLite_AppGroup` convention:

```xml
<key>RNNitroSQLite_DatabaseLocation</key>
<string>ApplicationSupport</string>
```

- Supported values: `Documents` (default, current behavior) and `ApplicationSupport`. Making this opt-in avoids a breaking change for apps that rely on Files-app access to their databases — though I'd be happy to flip the default in a future major if you prefer, since the migration makes that safe data-wise.
- When set to `ApplicationSupport`, `OnLoad.mm` points `docPath` at `Library/Application Support` (creating it if needed) and records the old Documents path in a new `HybridNitroSQLite::migrationDocPath`.
- Databases created by older app versions are migrated out of Documents lazily, in `HybridNitroSQLite::open()`, where the database name is known — so the migration is fully generic. It also honors the `location` option (migrates `Documents/<location>` → `Application Support/<location>`).
- No effect on Android or when `RNNitroSQLite_AppGroup` is set (app group databases live in the shared container). `migrationDocPath` stays empty in those cases, making the `open()` change a no-op.

## Migration safety

Committed-but-uncheckpointed writes live in the `-wal` file, and SQLite only replays a `-wal` that sits next to its database, so the database and its journals must never be separated. The migration therefore:

1. Removes any stale set at the destination first (e.g. after a downgrade → re-upgrade cycle), so a `-wal` from one database generation is never replayed into a database from another.
2. Copies the whole set (`db`, `-wal`, `-shm`) before deleting anything. If any copy fails, the intact originals in Documents keep being used — `open()` falls back to opening the database from Documents — and the migration retries on the next open.
3. Deletes the source database first and its journals only once that succeeds: if the database can't be removed, the fallback keeps opening it from Documents, so its `-wal` must stay next to it.
4. Sweeps leftover journal files out of Documents on a later open if a previous run was interrupted between deletes.

This exact strategy has been running in the Expensify app in production.

## Notes

- Migration is wired into `open()` only. `attach()`/`drop()` on a never-opened database would still look in the new location; I kept the scope minimal, but happy to extend it to those paths if you'd like.
- Uses `std::filesystem`, available on all deployment targets Nitro supports.

## Testing

- Fresh install with the key set → database is created in `Library/Application Support`.
- Upgrade path: database created in Documents by a build without the key, then opened by a build with the key → database and journals moved to `Library/Application Support`, uncheckpointed WAL content preserved.
- Without the key (or with `Documents`) → behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
