### PR TITLE
feat(ios): store databases in Application Support safely

### DIFF
--- a/.github/workflows/test-cpp.yml
+++ b/.github/workflows/test-cpp.yml
@@ -8,12 +8,14 @@ on:
       - ".github/workflows/test-cpp.yml"
       - "packages/react-native-nitro-sqlite/cpp/databaseMigration.*"
       - "packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.cpp"
+      - "packages/react-native-nitro-sqlite/cpp/sqlite/sqlite3.*"
       - "packages/react-native-nitro-sqlite/tests/cpp/**"
   pull_request:
     paths:
       - ".github/workflows/test-cpp.yml"
       - "packages/react-native-nitro-sqlite/cpp/databaseMigration.*"
       - "packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.cpp"
+      - "packages/react-native-nitro-sqlite/cpp/sqlite/sqlite3.*"
       - "packages/react-native-nitro-sqlite/tests/cpp/**"
 
 jobs:
@@ -23,6 +25,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Build bundled SQLite
+        run: |
+          clang \
+            -std=c11 \
+            -DSQLITE_THREADSAFE=2 \
+            -c packages/react-native-nitro-sqlite/cpp/sqlite/sqlite3.c \
+            -o /tmp/sqlite3.o
+
       - name: Build migration tests
         run: |
           clang++ \
@@ -31,8 +41,13 @@ jobs:
             -Wextra \
             -Werror \
             -Ipackages/react-native-nitro-sqlite/cpp \
+            -Ipackages/react-native-nitro-sqlite/cpp/sqlite \
             packages/react-native-nitro-sqlite/cpp/databaseMigration.cpp \
             packages/react-native-nitro-sqlite/tests/cpp/databaseMigration.test.cpp \
+            /tmp/sqlite3.o \
+            -ldl \
+            -lm \
+            -pthread \
             -o /tmp/databaseMigrationTests
 
       - name: Run migration tests

--- a/.github/workflows/test-cpp.yml
+++ b/.github/workflows/test-cpp.yml
@@ -1,0 +1,39 @@
+name: Test C++
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/test-cpp.yml"
+      - "packages/react-native-nitro-sqlite/cpp/databaseMigration.*"
+      - "packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.cpp"
+      - "packages/react-native-nitro-sqlite/tests/cpp/**"
+  pull_request:
+    paths:
+      - ".github/workflows/test-cpp.yml"
+      - "packages/react-native-nitro-sqlite/cpp/databaseMigration.*"
+      - "packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.cpp"
+      - "packages/react-native-nitro-sqlite/tests/cpp/**"
+
+jobs:
+  test:
+    name: Database migration tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build migration tests
+        run: |
+          clang++ \
+            -std=c++20 \
+            -Wall \
+            -Wextra \
+            -Werror \
+            -Ipackages/react-native-nitro-sqlite/cpp \
+            packages/react-native-nitro-sqlite/cpp/databaseMigration.cpp \
+            packages/react-native-nitro-sqlite/tests/cpp/databaseMigration.test.cpp \
+            -o /tmp/databaseMigrationTests
+
+      - name: Run migration tests
+        run: /tmp/databaseMigrationTests

--- a/README.md
+++ b/README.md
@@ -329,6 +329,23 @@ nitroSqliteFlags="-DSQLITE_ENABLE_FTS5=1"
 
 To put the database in an app group (e.g. for extensions), set `RNNitroSQLite_AppGroup` in your `Info.plist` to the app group ID and add the App Groups capability in Xcode.
 
+## Database location (iOS)
+
+By default, databases are stored in the app's **Documents** directory. If your app enables file sharing (`UIFileSharingEnabled` + `LSSupportsOpeningDocumentsInPlace`), that directory — including your raw database and its `-wal`/`-shm` journal files — becomes visible to users in the Files app, where they can be shared, modified, or deleted from outside your app.
+
+To store databases in `Library/Application Support` instead (persistent, backed up, and never user-visible), set `RNNitroSQLite_DatabaseLocation` in your `Info.plist`:
+
+```xml
+<key>RNNitroSQLite_DatabaseLocation</key>
+<string>ApplicationSupport</string>
+```
+
+Supported values are `Documents` (the default) and `ApplicationSupport`.
+
+Databases created while the app was still using the Documents directory are automatically moved to `Library/Application Support` the first time they are opened after enabling this option, so existing users keep their data. If you later remove the option, databases already moved to `Library/Application Support` are **not** moved back.
+
+This option has no effect when `RNNitroSQLite_AppGroup` is set, since app group databases live in the shared container.
+
 ---
 
 # Exports

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ To store databases in `Library/Application Support` instead (persistent, backed 
 
 Supported values are `Documents` (the default) and `ApplicationSupport`.
 
-Databases created while the app was still using the Documents directory are automatically moved to `Library/Application Support` the first time they are opened after enabling this option, so existing users keep their data. If you later remove the option, databases already moved to `Library/Application Support` are **not** moved back.
+Databases created while the app was still using the Documents directory are automatically moved to `Library/Application Support` the first time they are opened or attached after enabling this option, so existing users keep their data. Deleting a database also removes any copy left in Documents by an interrupted migration. If you later remove the option, databases already moved to `Library/Application Support` are **not** moved back.
 
 This option has no effect when `RNNitroSQLite_AppGroup` is set, since app group databases live in the shared container.
 

--- a/packages/react-native-nitro-sqlite/cpp/databaseMigration.cpp
+++ b/packages/react-native-nitro-sqlite/cpp/databaseMigration.cpp
@@ -1,0 +1,123 @@
+#include "databaseMigration.hpp"
+#include "logs.hpp"
+#include <array>
+#include <system_error>
+
+namespace margelo::nitro::rnnitrosqlite {
+
+namespace fs = std::filesystem;
+
+namespace {
+
+  constexpr std::size_t kDatabaseFileCount = 4;
+  using DatabaseFiles = std::array<std::string, kDatabaseFileCount>;
+
+  DatabaseFiles getDatabaseFiles(const std::string& dbName);
+  bool copyDatabaseFiles(const DatabaseFiles& files, const fs::path& fromDirectory, const fs::path& toDirectory);
+  void removeAuxiliaryDatabaseFiles(const DatabaseFiles& files, const fs::path& directory);
+
+} // namespace
+
+fs::path migrateDatabase(const std::string& dbName, const fs::path& fromDirectory, const fs::path& toDirectory) {
+  const auto files = getDatabaseFiles(dbName);
+  std::error_code ec;
+  const bool sourceExists = fs::exists(fromDirectory / dbName, ec);
+
+  if (ec) {
+    LOGW("Failed to inspect database %s in its old location: %s", dbName.c_str(), ec.message().c_str());
+    return fromDirectory;
+  }
+
+  if (!sourceExists) {
+    // A completed migration may have been interrupted after deleting the database but before
+    // deleting its journals. The destination is already authoritative in that state.
+    removeAuxiliaryDatabaseFiles(files, fromDirectory);
+    return toDirectory;
+  }
+
+  // A database in the old directory is the live copy. Clear every database generation file at
+  // the destination before copying so SQLite never pairs the source with a stale journal.
+  if (!removeDatabaseFiles(dbName, toDirectory)) {
+    return fromDirectory;
+  }
+
+  fs::create_directories(toDirectory, ec);
+  if (ec) {
+    LOGW("Failed to create database migration directory %s: %s", toDirectory.string().c_str(), ec.message().c_str());
+    return fromDirectory;
+  }
+
+  if (!copyDatabaseFiles(files, fromDirectory, toDirectory)) {
+    return fromDirectory;
+  }
+
+  // Delete the database first. If this fails, every source journal must remain beside it so the
+  // caller can safely keep using the old location. Leftover journals after a successful database
+  // deletion are harmless and are removed on the next migration attempt.
+  if (!fs::remove(fromDirectory / dbName, ec) || ec) {
+    LOGW("Failed to remove migrated database %s from its old location: %s", dbName.c_str(), ec.message().c_str());
+    return fromDirectory;
+  }
+
+  removeAuxiliaryDatabaseFiles(files, fromDirectory);
+  return toDirectory;
+}
+
+bool removeDatabaseFiles(const std::string& dbName, const fs::path& directory) {
+  const auto files = getDatabaseFiles(dbName);
+
+  for (const auto& file : files) {
+    std::error_code ec;
+    fs::remove(directory / file, ec);
+    if (ec) {
+      LOGW("Failed to remove database file %s: %s", file.c_str(), ec.message().c_str());
+      return false;
+    }
+  }
+
+  return true;
+}
+
+namespace {
+
+  DatabaseFiles getDatabaseFiles(const std::string& dbName) {
+    return {dbName, dbName + "-journal", dbName + "-wal", dbName + "-shm"};
+  }
+
+  bool copyDatabaseFiles(const DatabaseFiles& files, const fs::path& fromDirectory, const fs::path& toDirectory) {
+    for (const auto& file : files) {
+      std::error_code ec;
+      const bool sourceExists = fs::exists(fromDirectory / file, ec);
+
+      if (ec) {
+        LOGW("Failed to inspect database file %s: %s", file.c_str(), ec.message().c_str());
+        return false;
+      }
+
+      if (!sourceExists) {
+        continue;
+      }
+
+      if (!fs::copy_file(fromDirectory / file, toDirectory / file, ec) || ec) {
+        LOGW("Failed to migrate database file %s: %s", file.c_str(), ec.message().c_str());
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  void removeAuxiliaryDatabaseFiles(const DatabaseFiles& files, const fs::path& directory) {
+    for (std::size_t index = 1; index < files.size(); index++) {
+      const auto& file = files[index];
+      std::error_code ec;
+      fs::remove(directory / file, ec);
+      if (ec) {
+        LOGW("Failed to remove database file %s: %s", file.c_str(), ec.message().c_str());
+      }
+    }
+  }
+
+} // namespace
+
+} // namespace margelo::nitro::rnnitrosqlite

--- a/packages/react-native-nitro-sqlite/cpp/databaseMigration.hpp
+++ b/packages/react-native-nitro-sqlite/cpp/databaseMigration.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace margelo::nitro::rnnitrosqlite {
+
+std::filesystem::path migrateDatabase(const std::string& dbName, const std::filesystem::path& fromDirectory,
+                                      const std::filesystem::path& toDirectory);
+
+bool removeDatabaseFiles(const std::string& dbName, const std::filesystem::path& directory);
+
+} // namespace margelo::nitro::rnnitrosqlite

--- a/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.cpp
+++ b/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.cpp
@@ -1,6 +1,7 @@
 #include "HybridNitroSQLite.hpp"
 #include "HybridNitroSQLiteQueryResult.hpp"
 #include "NitroSQLiteException.hpp"
+#include "databaseMigration.hpp"
 #include "importSqlFile.hpp"
 #include "logs.hpp"
 #include "macros.hpp"
@@ -66,76 +67,26 @@ const std::string getDocPath(const std::optional<std::string>& location) {
   return tempDocPath;
 }
 
-// Moves a database (together with its -wal/-shm journal files) out of the directory a previous
-// app version stored it in. Committed-but-uncheckpointed writes live in the -wal file and SQLite
-// only replays it when it sits next to its database, so the set must never be separated: the
-// whole set is copied before any original is deleted, and if anything fails the intact originals
-// stay in place (the caller then keeps opening the database there) and the migration retries on
-// the next open.
-static void migrateDatabase(const std::string& dbName, const std::filesystem::path& fromDirectory,
-                            const std::filesystem::path& toDirectory) {
-  namespace fs = std::filesystem;
-  const std::string files[] = {dbName, dbName + "-wal", dbName + "-shm"};
-  std::error_code ec;
-
-  if (!fs::exists(fromDirectory / dbName, ec)) {
-    // Nothing to migrate. A previous run may have been interrupted after copying the set but
-    // before removing the journal files, so sweep any leftovers out of the old directory.
-    fs::remove(fromDirectory / (dbName + "-wal"), ec);
-    fs::remove(fromDirectory / (dbName + "-shm"), ec);
-    return;
+const std::string getOldDocPath(const std::optional<std::string>& location) {
+  std::string oldDocPath = HybridNitroSQLite::migrationDocPath;
+  if (location) {
+    oldDocPath = oldDocPath + "/" + *location;
   }
 
-  // A database in the old directory means an older app version was writing there, so it is the
-  // live copy. Remove whatever sits at the destination (e.g. after a downgrade and re-upgrade)
-  // so a -wal from one database generation is never replayed into a database from another.
-  for (const auto& file : files) {
-    fs::remove(toDirectory / file, ec);
+  return oldDocPath;
+}
+
+const std::string getMigratedDocPath(const std::string& dbName, const std::optional<std::string>& location) {
+  const auto currentDocPath = getDocPath(location);
+  if (HybridNitroSQLite::migrationDocPath.empty()) {
+    return currentDocPath;
   }
 
-  fs::create_directories(toDirectory, ec);
-  for (const auto& file : files) {
-    if (!fs::exists(fromDirectory / file, ec)) {
-      continue;
-    }
-
-    if (!fs::copy_file(fromDirectory / file, toDirectory / file, ec) || ec) {
-      LOGW("Failed to migrate database file %s: %s", file.c_str(), ec.message().c_str());
-      return;
-    }
-  }
-
-  // The database file is deleted first, and the journals only once that succeeds: if the
-  // database cannot be removed, the caller keeps opening it from the old directory, so its -wal
-  // must stay next to it or committed writes would be lost. An interruption after the first
-  // delete can only leave journal files behind, which the sweep above removes on the next open.
-  if (!fs::remove(fromDirectory / dbName, ec) || ec) {
-    LOGW("Failed to remove migrated database %s from its old location: %s", dbName.c_str(), ec.message().c_str());
-    return;
-  }
-  fs::remove(fromDirectory / (dbName + "-wal"), ec);
-  fs::remove(fromDirectory / (dbName + "-shm"), ec);
+  return migrateDatabase(dbName, getOldDocPath(location), currentDocPath).string();
 }
 
 void HybridNitroSQLite::open(const std::string& dbName, const std::optional<std::string>& location) {
-  auto docPath = getDocPath(location);
-
-  if (!migrationDocPath.empty()) {
-    std::string oldDocPath = migrationDocPath;
-    if (location) {
-      oldDocPath = oldDocPath + "/" + *location;
-    }
-
-    migrateDatabase(dbName, oldDocPath, docPath);
-
-    // If the database could not be moved out of its old directory, keep opening it there rather
-    // than creating a fresh empty one; the migration retries on the next open.
-    std::error_code ec;
-    if (std::filesystem::exists(std::filesystem::path(oldDocPath) / dbName, ec)) {
-      docPath = oldDocPath;
-    }
-  }
-
+  const auto docPath = getMigratedDocPath(dbName, location);
   sqliteOpenDb(dbName, docPath);
 }
 
@@ -144,18 +95,28 @@ void HybridNitroSQLite::close(const std::string& dbName) {
 };
 
 void HybridNitroSQLite::drop(const std::string& dbName, const std::optional<std::string>& location) {
-  const auto docPath = getDocPath(location);
-  sqliteRemoveDb(dbName, docPath);
+  const auto currentDocPath = getDocPath(location);
+  if (migrationDocPath.empty()) {
+    sqliteRemoveDb(dbName, currentDocPath);
+    return;
+  }
+
+  const auto oldDocPath = getOldDocPath(location);
+  std::error_code ec;
+  const bool oldDatabaseExists = std::filesystem::exists(std::filesystem::path(oldDocPath) / dbName, ec);
+  if (ec) {
+    LOGW("Failed to inspect database %s in its old location: %s", dbName.c_str(), ec.message().c_str());
+  }
+
+  sqliteRemoveDb(dbName, oldDatabaseExists || ec ? oldDocPath : currentDocPath);
+  removeDatabaseFiles(dbName, oldDocPath);
+  removeDatabaseFiles(dbName, currentDocPath);
 };
 
 void HybridNitroSQLite::attach(const std::string& mainDbName, const std::string& dbNameToAttach, const std::string& alias,
                                const std::optional<std::string>& location) {
-  std::string tempDocPath = std::string(docPath);
-  if (location) {
-    tempDocPath = tempDocPath + "/" + *location;
-  }
-
-  sqliteAttachDb(mainDbName, tempDocPath, dbNameToAttach, alias);
+  const auto attachedDocPath = getMigratedDocPath(dbNameToAttach, location);
+  sqliteAttachDb(mainDbName, attachedDocPath, dbNameToAttach, alias);
 };
 
 void HybridNitroSQLite::detach(const std::string& mainDbName, const std::string& alias) {

--- a/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.cpp
+++ b/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.cpp
@@ -6,6 +6,7 @@
 #include "macros.hpp"
 #include "operations.hpp"
 #include "sqliteExecuteBatch.hpp"
+#include <filesystem>
 #include <iostream>
 #include <map>
 #include <optional>
@@ -65,8 +66,76 @@ const std::string getDocPath(const std::optional<std::string>& location) {
   return tempDocPath;
 }
 
+// Moves a database (together with its -wal/-shm journal files) out of the directory a previous
+// app version stored it in. Committed-but-uncheckpointed writes live in the -wal file and SQLite
+// only replays it when it sits next to its database, so the set must never be separated: the
+// whole set is copied before any original is deleted, and if anything fails the intact originals
+// stay in place (the caller then keeps opening the database there) and the migration retries on
+// the next open.
+static void migrateDatabase(const std::string& dbName, const std::filesystem::path& fromDirectory,
+                            const std::filesystem::path& toDirectory) {
+  namespace fs = std::filesystem;
+  const std::string files[] = {dbName, dbName + "-wal", dbName + "-shm"};
+  std::error_code ec;
+
+  if (!fs::exists(fromDirectory / dbName, ec)) {
+    // Nothing to migrate. A previous run may have been interrupted after copying the set but
+    // before removing the journal files, so sweep any leftovers out of the old directory.
+    fs::remove(fromDirectory / (dbName + "-wal"), ec);
+    fs::remove(fromDirectory / (dbName + "-shm"), ec);
+    return;
+  }
+
+  // A database in the old directory means an older app version was writing there, so it is the
+  // live copy. Remove whatever sits at the destination (e.g. after a downgrade and re-upgrade)
+  // so a -wal from one database generation is never replayed into a database from another.
+  for (const auto& file : files) {
+    fs::remove(toDirectory / file, ec);
+  }
+
+  fs::create_directories(toDirectory, ec);
+  for (const auto& file : files) {
+    if (!fs::exists(fromDirectory / file, ec)) {
+      continue;
+    }
+
+    if (!fs::copy_file(fromDirectory / file, toDirectory / file, ec) || ec) {
+      LOGW("Failed to migrate database file %s: %s", file.c_str(), ec.message().c_str());
+      return;
+    }
+  }
+
+  // The database file is deleted first, and the journals only once that succeeds: if the
+  // database cannot be removed, the caller keeps opening it from the old directory, so its -wal
+  // must stay next to it or committed writes would be lost. An interruption after the first
+  // delete can only leave journal files behind, which the sweep above removes on the next open.
+  if (!fs::remove(fromDirectory / dbName, ec) || ec) {
+    LOGW("Failed to remove migrated database %s from its old location: %s", dbName.c_str(), ec.message().c_str());
+    return;
+  }
+  fs::remove(fromDirectory / (dbName + "-wal"), ec);
+  fs::remove(fromDirectory / (dbName + "-shm"), ec);
+}
+
 void HybridNitroSQLite::open(const std::string& dbName, const std::optional<std::string>& location) {
-  const auto docPath = getDocPath(location);
+  auto docPath = getDocPath(location);
+
+  if (!migrationDocPath.empty()) {
+    std::string oldDocPath = migrationDocPath;
+    if (location) {
+      oldDocPath = oldDocPath + "/" + *location;
+    }
+
+    migrateDatabase(dbName, oldDocPath, docPath);
+
+    // If the database could not be moved out of its old directory, keep opening it there rather
+    // than creating a fresh empty one; the migration retries on the next open.
+    std::error_code ec;
+    if (std::filesystem::exists(std::filesystem::path(oldDocPath) / dbName, ec)) {
+      docPath = oldDocPath;
+    }
+  }
+
   sqliteOpenDb(dbName, docPath);
 }
 

--- a/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.cpp
+++ b/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.cpp
@@ -7,8 +7,8 @@
 #include "macros.hpp"
 #include "operations.hpp"
 #include "sqliteExecuteBatch.hpp"
-#include <filesystem>
 #include <exception>
+#include <filesystem>
 #include <iostream>
 #include <map>
 #include <optional>

--- a/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.hpp
+++ b/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.hpp
@@ -16,7 +16,7 @@ public:
   static std::string docPath;
   // Directory databases were stored in by previous app versions, when the platform layer has
   // relocated docPath (e.g. iOS with RNNitroSQLite_DatabaseLocation set to "ApplicationSupport").
-  // When non-empty, each database found there is moved to docPath as it is opened.
+  // When non-empty, databases found there are resolved as they are opened, attached, or dropped.
   static std::string migrationDocPath;
 
 public:

--- a/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.hpp
+++ b/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.hpp
@@ -14,6 +14,10 @@ public:
 
 public:
   static std::string docPath;
+  // Directory databases were stored in by previous app versions, when the platform layer has
+  // relocated docPath (e.g. iOS with RNNitroSQLite_DatabaseLocation set to "ApplicationSupport").
+  // When non-empty, each database found there is moved to docPath as it is opened.
+  static std::string migrationDocPath;
 
 public:
   // Methods
@@ -43,5 +47,6 @@ public:
 };
 
 inline std::string HybridNitroSQLite::docPath = "";
+inline std::string HybridNitroSQLite::migrationDocPath = "";
 
 } // namespace margelo::nitro::rnnitrosqlite

--- a/packages/react-native-nitro-sqlite/ios/OnLoad.mm
+++ b/packages/react-native-nitro-sqlite/ios/OnLoad.mm
@@ -30,9 +30,32 @@ using namespace margelo::nitro::rnnitrosqlite;
 
     documentPath = [storeUrl path];
   } else {
-    // Get iOS app's document directory (to safely store database .sqlite3 file)
-    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, true);
-    documentPath = [paths objectAtIndex:0];
+    NSString *databaseLocation = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RNNitroSQLite_DatabaseLocation"];
+
+    if ([databaseLocation isEqualToString:@"ApplicationSupport"]) {
+      // Library/Application Support is persistent, backed up, and never exposed to the user
+      // via the Files app (unlike the Documents directory, which becomes user-visible when
+      // the app enables file sharing).
+      NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, true);
+      documentPath = [paths objectAtIndex:0];
+
+      NSFileManager *fileManager = [NSFileManager defaultManager];
+      if (![fileManager fileExistsAtPath:documentPath]) {
+        [fileManager createDirectoryAtPath:documentPath withIntermediateDirectories:YES attributes:nil error:nil];
+      }
+
+      // Databases created before this option was enabled still live in Documents; each one is
+      // moved over when it is opened (see HybridNitroSQLite::open).
+      NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, true) objectAtIndex:0];
+      HybridNitroSQLite::migrationDocPath = [documentsDirectory UTF8String];
+    } else {
+      if (databaseLocation != nil && ![databaseLocation isEqualToString:@"Documents"]) {
+        NSLog(@"Invalid RNNitroSQLite_DatabaseLocation value provided (%@). Supported values are \"Documents\" and \"ApplicationSupport\". Falling back to \"Documents\".", databaseLocation);
+      }
+      // Get iOS app's document directory (to safely store database .sqlite3 file)
+      NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, true);
+      documentPath = [paths objectAtIndex:0];
+    }
   }
 
   HybridNitroSQLite::docPath = [documentPath UTF8String];

--- a/packages/react-native-nitro-sqlite/tests/cpp/databaseMigration.test.cpp
+++ b/packages/react-native-nitro-sqlite/tests/cpp/databaseMigration.test.cpp
@@ -1,0 +1,194 @@
+#include "databaseMigration.hpp"
+#include <array>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+
+namespace fs = std::filesystem;
+using namespace margelo::nitro::rnnitrosqlite;
+
+namespace {
+
+constexpr std::array<const char*, 4> kDatabaseSuffixes = {"", "-journal", "-wal", "-shm"};
+
+class TemporaryDirectory {
+public:
+  TemporaryDirectory() {
+    const auto uniqueId = std::chrono::steady_clock::now().time_since_epoch().count();
+    path = fs::temp_directory_path() / ("nitro-sqlite-migration-" + std::to_string(uniqueId));
+    fs::create_directories(path);
+  }
+
+  ~TemporaryDirectory() {
+    std::error_code ec;
+    fs::remove_all(path, ec);
+  }
+
+  fs::path path;
+};
+
+void migratesDatabaseAndEveryJournalType();
+void removesStaleDestinationJournalsMissingFromSource();
+void fallsBackWithoutChangingSourceFilesWhenDestinationCleanupFails();
+void removesOrphanedSourceJournalsAfterAnInterruptedMigration();
+void removesEveryDatabaseGenerationFile();
+void writeFile(const fs::path& path, const std::string& contents);
+std::string readFile(const fs::path& path);
+void expect(bool condition, const std::string& message);
+
+} // namespace
+
+int main() {
+  struct TestCase {
+    const char* name;
+    void (*run)();
+  };
+
+  const TestCase tests[] = {
+      {"migrates database and every journal type", migratesDatabaseAndEveryJournalType},
+      {"removes stale destination journals missing from source", removesStaleDestinationJournalsMissingFromSource},
+      {"falls back without changing source files when destination cleanup fails",
+       fallsBackWithoutChangingSourceFilesWhenDestinationCleanupFails},
+      {"removes orphaned source journals after an interrupted migration", removesOrphanedSourceJournalsAfterAnInterruptedMigration},
+      {"removes every database generation file", removesEveryDatabaseGenerationFile},
+  };
+
+  int failures = 0;
+  for (const auto& test : tests) {
+    try {
+      test.run();
+      std::cout << "[PASS] " << test.name << '\n';
+    } catch (const std::exception& error) {
+      failures++;
+      std::cerr << "[FAIL] " << test.name << ": " << error.what() << '\n';
+    }
+  }
+
+  return failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+namespace {
+
+void migratesDatabaseAndEveryJournalType() {
+  TemporaryDirectory temporaryDirectory;
+  const auto source = temporaryDirectory.path / "Documents";
+  const auto destination = temporaryDirectory.path / "Application Support";
+  const std::string dbName = "database.sqlite";
+
+  for (const auto* suffix : kDatabaseSuffixes) {
+    const std::string fileName = dbName + suffix;
+    writeFile(source / fileName, "source:" + fileName);
+    writeFile(destination / fileName, "stale:" + fileName);
+  }
+
+  const auto resolvedDirectory = migrateDatabase(dbName, source, destination);
+
+  expect(resolvedDirectory == destination, "the destination should be selected after a successful migration");
+  for (const auto* suffix : kDatabaseSuffixes) {
+    const std::string fileName = dbName + suffix;
+    expect(!fs::exists(source / fileName), "the source file should be removed: " + fileName);
+    expect(readFile(destination / fileName) == "source:" + fileName, "the source should replace the stale file: " + fileName);
+  }
+}
+
+void removesStaleDestinationJournalsMissingFromSource() {
+  TemporaryDirectory temporaryDirectory;
+  const auto source = temporaryDirectory.path / "Documents";
+  const auto destination = temporaryDirectory.path / "Application Support";
+  const std::string dbName = "database.sqlite";
+
+  writeFile(source / dbName, "source database");
+  writeFile(destination / dbName, "stale database");
+  for (std::size_t index = 1; index < kDatabaseSuffixes.size(); index++) {
+    writeFile(destination / (dbName + kDatabaseSuffixes[index]), "stale journal");
+  }
+
+  const auto resolvedDirectory = migrateDatabase(dbName, source, destination);
+
+  expect(resolvedDirectory == destination, "the destination should be selected after migration");
+  expect(readFile(destination / dbName) == "source database", "the source database should replace the stale database");
+  for (std::size_t index = 1; index < kDatabaseSuffixes.size(); index++) {
+    expect(!fs::exists(destination / (dbName + kDatabaseSuffixes[index])), "stale destination journals should be removed");
+  }
+}
+
+void fallsBackWithoutChangingSourceFilesWhenDestinationCleanupFails() {
+  TemporaryDirectory temporaryDirectory;
+  const auto source = temporaryDirectory.path / "Documents";
+  const auto destination = temporaryDirectory.path / "Application Support";
+  const std::string dbName = "database.sqlite";
+
+  for (const auto* suffix : kDatabaseSuffixes) {
+    const std::string fileName = dbName + suffix;
+    writeFile(source / fileName, "source:" + fileName);
+  }
+  writeFile(destination / dbName / "child", "prevents directory removal");
+
+  const auto resolvedDirectory = migrateDatabase(dbName, source, destination);
+
+  expect(resolvedDirectory == source, "the source should remain selected when destination cleanup fails");
+  for (const auto* suffix : kDatabaseSuffixes) {
+    const std::string fileName = dbName + suffix;
+    expect(readFile(source / fileName) == "source:" + fileName, "fallback should preserve the source file: " + fileName);
+  }
+}
+
+void removesOrphanedSourceJournalsAfterAnInterruptedMigration() {
+  TemporaryDirectory temporaryDirectory;
+  const auto source = temporaryDirectory.path / "Documents";
+  const auto destination = temporaryDirectory.path / "Application Support";
+  const std::string dbName = "database.sqlite";
+
+  writeFile(destination / dbName, "migrated database");
+  for (std::size_t index = 1; index < kDatabaseSuffixes.size(); index++) {
+    writeFile(source / (dbName + kDatabaseSuffixes[index]), "orphaned journal");
+  }
+
+  const auto resolvedDirectory = migrateDatabase(dbName, source, destination);
+
+  expect(resolvedDirectory == destination, "the completed migration should keep using the destination");
+  expect(readFile(destination / dbName) == "migrated database", "the migrated database should remain unchanged");
+  for (std::size_t index = 1; index < kDatabaseSuffixes.size(); index++) {
+    expect(!fs::exists(source / (dbName + kDatabaseSuffixes[index])), "orphaned source journals should be removed");
+  }
+}
+
+void removesEveryDatabaseGenerationFile() {
+  TemporaryDirectory temporaryDirectory;
+  const auto directory = temporaryDirectory.path / "Database";
+  const std::string dbName = "database.sqlite";
+
+  for (const auto* suffix : kDatabaseSuffixes) {
+    writeFile(directory / (dbName + suffix), "database generation file");
+  }
+
+  expect(removeDatabaseFiles(dbName, directory), "database file cleanup should succeed");
+  for (const auto* suffix : kDatabaseSuffixes) {
+    expect(!fs::exists(directory / (dbName + suffix)), "database generation files should be removed");
+  }
+}
+
+void writeFile(const fs::path& path, const std::string& contents) {
+  fs::create_directories(path.parent_path());
+  std::ofstream file(path, std::ios::binary);
+  file << contents;
+  expect(file.good(), "failed to write test file: " + path.string());
+}
+
+std::string readFile(const fs::path& path) {
+  std::ifstream file(path, std::ios::binary);
+  return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+}
+
+void expect(bool condition, const std::string& message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+} // namespace

--- a/packages/react-native-nitro-sqlite/tests/cpp/databaseMigration.test.cpp
+++ b/packages/react-native-nitro-sqlite/tests/cpp/databaseMigration.test.cpp
@@ -1,13 +1,19 @@
 #include "databaseMigration.hpp"
 #include <array>
+#include <cerrno>
 #include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <iterator>
+#include <sqlite3.h>
 #include <stdexcept>
 #include <string>
+#include <sys/wait.h>
+#include <unistd.h>
 
 namespace fs = std::filesystem;
 using namespace margelo::nitro::rnnitrosqlite;
@@ -15,6 +21,8 @@ using namespace margelo::nitro::rnnitrosqlite;
 namespace {
 
 constexpr std::array<const char*, 4> kDatabaseSuffixes = {"", "-journal", "-wal", "-shm"};
+
+void expect(bool condition, const std::string& message);
 
 class TemporaryDirectory {
 public:
@@ -32,14 +40,88 @@ public:
   fs::path path;
 };
 
+class SQLiteDatabase {
+public:
+  explicit SQLiteDatabase(const fs::path& path) {
+    const int result = sqlite3_open(path.string().c_str(), &database);
+    if (result == SQLITE_OK) {
+      return;
+    }
+
+    const std::string message = database == nullptr ? sqlite3_errstr(result) : sqlite3_errmsg(database);
+    sqlite3_close_v2(database);
+    database = nullptr;
+    throw std::runtime_error("failed to open SQLite database: " + message);
+  }
+
+  ~SQLiteDatabase() {
+    sqlite3_close_v2(database);
+  }
+
+  SQLiteDatabase(const SQLiteDatabase&) = delete;
+  SQLiteDatabase& operator=(const SQLiteDatabase&) = delete;
+
+  void execute(const std::string& sql) {
+    char* errorMessage = nullptr;
+    const int result = sqlite3_exec(database, sql.c_str(), nullptr, nullptr, &errorMessage);
+    if (result == SQLITE_OK) {
+      return;
+    }
+
+    const std::string message = errorMessage == nullptr ? sqlite3_errmsg(database) : errorMessage;
+    sqlite3_free(errorMessage);
+    throw std::runtime_error("SQLite statement failed: " + message);
+  }
+
+  std::string queryText(const std::string& sql) {
+    sqlite3_stmt* statement = nullptr;
+    int result = sqlite3_prepare_v2(database, sql.c_str(), -1, &statement, nullptr);
+    if (result != SQLITE_OK) {
+      throw std::runtime_error("failed to prepare SQLite query: " + std::string(sqlite3_errmsg(database)));
+    }
+
+    result = sqlite3_step(statement);
+    if (result != SQLITE_ROW) {
+      const std::string message = sqlite3_errmsg(database);
+      sqlite3_finalize(statement);
+      throw std::runtime_error("SQLite query returned no row: " + message);
+    }
+
+    const auto* value = reinterpret_cast<const char*>(sqlite3_column_text(statement, 0));
+    const std::string text = value == nullptr ? "" : value;
+    result = sqlite3_finalize(statement);
+    if (result != SQLITE_OK) {
+      throw std::runtime_error("failed to finalize SQLite query: " + std::string(sqlite3_errmsg(database)));
+    }
+
+    return text;
+  }
+
+  void flushCache() {
+    const int result = sqlite3_db_cacheflush(database);
+    if (result != SQLITE_OK) {
+      throw std::runtime_error("failed to flush SQLite cache: " + std::string(sqlite3_errmsg(database)));
+    }
+  }
+
+  void abandonWithoutClosing() {
+    database = nullptr;
+  }
+
+private:
+  sqlite3* database = nullptr;
+};
+
 void migratesDatabaseAndEveryJournalType();
 void removesStaleDestinationJournalsMissingFromSource();
 void fallsBackWithoutChangingSourceFilesWhenDestinationCleanupFails();
 void removesOrphanedSourceJournalsAfterAnInterruptedMigration();
 void removesEveryDatabaseGenerationFile();
+void recoversCommittedWalAfterMigration();
+void rollsBackHotJournalAfterMigration();
+void runWithoutCleanShutdown(const std::function<void()>& action);
 void writeFile(const fs::path& path, const std::string& contents);
 std::string readFile(const fs::path& path);
-void expect(bool condition, const std::string& message);
 
 } // namespace
 
@@ -56,6 +138,8 @@ int main() {
        fallsBackWithoutChangingSourceFilesWhenDestinationCleanupFails},
       {"removes orphaned source journals after an interrupted migration", removesOrphanedSourceJournalsAfterAnInterruptedMigration},
       {"removes every database generation file", removesEveryDatabaseGenerationFile},
+      {"recovers committed WAL content after migration", recoversCommittedWalAfterMigration},
+      {"rolls back a hot journal after migration", rollsBackHotJournalAfterMigration},
   };
 
   int failures = 0;
@@ -171,6 +255,115 @@ void removesEveryDatabaseGenerationFile() {
   for (const auto* suffix : kDatabaseSuffixes) {
     expect(!fs::exists(directory / (dbName + suffix)), "database generation files should be removed");
   }
+}
+
+void recoversCommittedWalAfterMigration() {
+  TemporaryDirectory temporaryDirectory;
+  const auto source = temporaryDirectory.path / "Documents";
+  const auto destination = temporaryDirectory.path / "Application Support";
+  const auto control = temporaryDirectory.path / "without-wal.sqlite";
+  const std::string dbName = "wal.sqlite";
+  const auto sourceDatabase = source / dbName;
+
+  fs::create_directories(source);
+  {
+    SQLiteDatabase database(sourceDatabase);
+    database.execute("PRAGMA journal_mode=WAL");
+    database.execute("CREATE TABLE records (id INTEGER PRIMARY KEY, value TEXT NOT NULL)");
+  }
+
+  runWithoutCleanShutdown([&]() {
+    SQLiteDatabase database(sourceDatabase);
+    database.execute("PRAGMA wal_autocheckpoint=0");
+    database.execute("INSERT INTO records (value) VALUES ('committed in WAL')");
+    database.abandonWithoutClosing();
+  });
+
+  expect(fs::exists(sourceDatabase.string() + "-wal"), "the crashed writer should leave a WAL file");
+  fs::copy_file(sourceDatabase, control);
+  {
+    SQLiteDatabase database(control);
+    expect(database.queryText("SELECT COUNT(*) FROM records") == "0", "the committed row should exist only in the WAL fixture");
+  }
+
+  const auto resolvedDirectory = migrateDatabase(dbName, source, destination);
+
+  expect(resolvedDirectory == destination, "the WAL database should migrate to the destination");
+  SQLiteDatabase migratedDatabase(destination / dbName);
+  expect(migratedDatabase.queryText("SELECT value FROM records WHERE id = 1") == "committed in WAL",
+         "opening the migrated database should recover committed WAL content");
+  expect(migratedDatabase.queryText("PRAGMA integrity_check") == "ok", "the migrated WAL database should pass integrity_check");
+}
+
+void rollsBackHotJournalAfterMigration() {
+  TemporaryDirectory temporaryDirectory;
+  const auto source = temporaryDirectory.path / "Documents";
+  const auto destination = temporaryDirectory.path / "Application Support";
+  const auto control = temporaryDirectory.path / "without-journal.sqlite";
+  const std::string dbName = "rollback.sqlite";
+  const auto sourceDatabase = source / dbName;
+
+  fs::create_directories(source);
+  {
+    SQLiteDatabase database(sourceDatabase);
+    database.execute("PRAGMA journal_mode=DELETE");
+    database.execute("PRAGMA synchronous=FULL");
+    database.execute("CREATE TABLE records (id INTEGER PRIMARY KEY, value TEXT NOT NULL)");
+    database.execute("INSERT INTO records (value) VALUES ('committed value')");
+  }
+
+  runWithoutCleanShutdown([&]() {
+    SQLiteDatabase database(sourceDatabase);
+    database.execute("PRAGMA journal_mode=DELETE");
+    database.execute("PRAGMA synchronous=FULL");
+    database.execute("BEGIN IMMEDIATE");
+    database.execute("UPDATE records SET value = 'uncommitted value' WHERE id = 1");
+    database.flushCache();
+    database.abandonWithoutClosing();
+  });
+
+  expect(fs::exists(sourceDatabase.string() + "-journal"), "the crashed writer should leave a rollback journal");
+  fs::copy_file(sourceDatabase, control);
+  {
+    SQLiteDatabase database(control);
+    expect(database.queryText("SELECT value FROM records WHERE id = 1") == "uncommitted value",
+           "the database fixture should require its rollback journal");
+  }
+
+  const auto resolvedDirectory = migrateDatabase(dbName, source, destination);
+
+  expect(resolvedDirectory == destination, "the rollback-journal database should migrate to the destination");
+  SQLiteDatabase migratedDatabase(destination / dbName);
+  expect(migratedDatabase.queryText("SELECT value FROM records WHERE id = 1") == "committed value",
+         "opening the migrated database should roll back the interrupted transaction");
+  expect(migratedDatabase.queryText("PRAGMA integrity_check") == "ok",
+         "the migrated rollback-journal database should pass integrity_check");
+}
+
+void runWithoutCleanShutdown(const std::function<void()>& action) {
+  const pid_t child = fork();
+  if (child == -1) {
+    throw std::runtime_error("failed to fork crash-test child process");
+  }
+
+  if (child == 0) {
+    try {
+      action();
+      _exit(EXIT_SUCCESS);
+    } catch (const std::exception& error) {
+      std::fprintf(stderr, "crash-test child failed: %s\n", error.what());
+      _exit(EXIT_FAILURE);
+    }
+  }
+
+  int status = 0;
+  pid_t waitResult;
+  do {
+    waitResult = waitpid(child, &status, 0);
+  } while (waitResult == -1 && errno == EINTR);
+
+  expect(waitResult == child, "failed to wait for crash-test child process");
+  expect(WIFEXITED(status) && WEXITSTATUS(status) == EXIT_SUCCESS, "crash-test child process failed");
 }
 
 void writeFile(const fs::path& path, const std::string& contents) {

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -2,6 +2,7 @@
 
 CPP_DIRS=(
   "packages/react-native-nitro-sqlite/cpp"
+  "packages/react-native-nitro-sqlite/tests/cpp"
 )
 
 if which clang-format >/dev/null; then


### PR DESCRIPTION
iOS apps that expose Documents through file sharing also expose Nitro SQLite databases, but moving those databases without every SQLite recovery file can corrupt data after a crash. #323 adds an opt-in Application Support location, but its migration omits rollback journals and only applies to databases passed through `open()`. This PR adds complete recovery-file handling plus consistent `open()`, `attach()`, and `drop()` behavior on top of @NicolasBonet's original changes.

- Migrates the database, rollback journal, WAL, and shared-memory files as one set.
- Removes stale destination journals before copying and keeps using the source after any inspection, cleanup, copy, or deletion failure.
- Migrates databases before `attach()` and removes old or partial generations from both locations during `drop()`.
- Adds C++ regression tests against the bundled SQLite, including real WAL and hot-journal recovery after an unclean process exit.

## Reproduction

1. Create primary and attached databases with a version that stores them in Documents.
2. Leave either a rollback journal or WAL files beside a database, then install a build with `RNNitroSQLite_DatabaseLocation` set to `ApplicationSupport`.
3. Open or attach each database and verify the database and its journal files move to Application Support without losing data.
4. Delete a database whose migration was interrupted and verify no old or partial generation remains in either location.

Fixes #289.
Supersedes #323.
