### PR TITLE
feat(ios): configure SQLite performance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,21 @@ With `SQLITE_THREADSAFE=0`, SQLite removes its mutex code and cannot be made thr
 
 When `NITRO_SQLITE_USE_PHONE_VERSION=1`, the pod links the system SQLite library instead of compiling the bundled source. `NITRO_SQLITE_THREADSAFE` does not change how that system library was compiled.
 
+## Configure SQLite performance mode on iOS
+
+The bundled SQLite library enables NitroSQLite's performance compile flags by default. Disable them independently from thread safety in your app's `package.json`:
+
+```json
+{
+  "nitroSQLite": {
+    "threadSafe": true,
+    "performanceMode": false
+  }
+}
+```
+
+`performanceMode` accepts `true` or `false`. `NITRO_SQLITE_PERFORMANCE_MODE` overrides the package setting for one Pod installation and accepts `true`, `false`, `1`, or `0`. Disabling performance mode omits NitroSQLite's SQLite optimization flags but does not change `SQLITE_THREADSAFE`.
+
 ## Use system SQLite on iOS
 
 To use the system SQLite instead of the bundled one:

--- a/example/package.json
+++ b/example/package.json
@@ -3,7 +3,8 @@
   "version": "9.6.0",
   "private": true,
   "nitroSQLite": {
-    "threadSafe": true
+    "threadSafe": true,
+    "performanceMode": true
   },
   "scripts": {
     "start": "react-native start",

--- a/packages/react-native-nitro-sqlite/RNNitroSQLite.podspec
+++ b/packages/react-native-nitro-sqlite/RNNitroSQLite.podspec
@@ -24,6 +24,21 @@ else
 
   sqlite_threadsafe = thread_safe_value ? "1" : "0"
 end
+
+if ENV.key?("NITRO_SQLITE_PERFORMANCE_MODE")
+  performance_mode_value = ENV["NITRO_SQLITE_PERFORMANCE_MODE"]
+  unless %w[true false 1 0].include?(performance_mode_value)
+    raise "NITRO_SQLITE_PERFORMANCE_MODE must be true, false, 1, or 0"
+  end
+
+  performance_mode = %w[true 1].include?(performance_mode_value)
+else
+  performance_mode = app_config.fetch("performanceMode", true)
+
+  unless [true, false].include?(performance_mode)
+    raise "nitroSQLite.performanceMode in package.json must be true or false"
+  end
+end
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1'
 log_message = lambda do |message|
   puts "\e[34m#{message}\e[0m"
@@ -52,10 +67,13 @@ Pod::Spec.new do |s|
     "cpp/**/*.{h,hpp,c,cpp}"
   ]
 
-  optimizedCflags = '$(inherited) -DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1 -DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1 -DSQLITE_MAX_EXPR_DEPTH=0 -DSQLITE_OMIT_DEPRECATED=1 -DSQLITE_OMIT_PROGRESS_CALLBACK=1 -DSQLITE_OMIT_SHARED_CACHE=1 -DSQLITE_USE_ALLOCA=1'
+  inherited_cflags = '$(inherited)'
+  optimized_cflags = '-DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1 -DSQLITE_LIKE_DOESNT_MATCH_BLOBS=1 -DSQLITE_MAX_EXPR_DEPTH=0 -DSQLITE_OMIT_DEPRECATED=1 -DSQLITE_OMIT_PROGRESS_CALLBACK=1 -DSQLITE_OMIT_SHARED_CACHE=1 -DSQLITE_USE_ALLOCA=1'
 
   log_message.call("SQLite thread safety: SQLITE_THREADSAFE=#{sqlite_threadsafe}")
-  other_cflags = optimizedCflags + " -DSQLITE_THREADSAFE=#{sqlite_threadsafe} "
+  log_message.call("SQLite performance mode: #{performance_mode ? "enabled" : "disabled"}")
+  performance_cflags = performance_mode ? " #{optimized_cflags}" : ""
+  other_cflags = "#{inherited_cflags}#{performance_cflags} -DSQLITE_THREADSAFE=#{sqlite_threadsafe} "
 
   s.pod_target_xcconfig = {
     :GCC_PREPROCESSOR_DEFINITIONS => "HAVE_FULLFSYNC=1",

--- a/scripts/test-podspec-threadsafe.rb
+++ b/scripts/test-podspec-threadsafe.rb
@@ -91,12 +91,36 @@ def main
   assert_threadsafe(environment_unsafe_flags, "0")
   assert_optimization_flags(environment_unsafe_flags)
 
+  unoptimized_flags = with_app_package("nitroSQLite" => {"performanceMode" => false}) do
+    flags_for(nil)
+  end
+  assert_threadsafe(unoptimized_flags, "1")
+  refute_optimization_flags(unoptimized_flags)
+
+  environment_enabled_flags = with_app_package("nitroSQLite" => {"performanceMode" => false}) do
+    flags_for(nil, "true")
+  end
+  assert_optimization_flags(environment_enabled_flags)
+
+  environment_override_invalid_package = with_app_package("nitroSQLite" => {"performanceMode" => 2}) do
+    flags_for(nil, "true")
+  end
+  assert_optimization_flags(environment_override_invalid_package)
+
+  environment_disabled_flags = with_app_package("nitroSQLite" => {"performanceMode" => true}) do
+    flags_for(nil, "false")
+  end
+  refute_optimization_flags(environment_disabled_flags)
+
   assert_invalid_package_value_rejected
   assert_invalid_package_config_rejected
   assert_invalid_environment_value_rejected
+  assert_invalid_package_performance_mode_rejected
+  assert_invalid_environment_performance_mode_rejected
   with_app_package({}) { assert_system_sqlite_configuration }
   compile_and_probe(unsafe_flags, "0")
   compile_and_probe(safe_flags, "1")
+  compile_and_probe(unoptimized_flags, "1")
 
   puts "SQLite pod configuration tests passed"
 end
@@ -111,9 +135,10 @@ def with_app_package(contents)
   end
 end
 
-def flags_for(threadsafe)
+def flags_for(threadsafe, performance_mode = nil)
   spec = evaluate_podspec(
     "NITRO_SQLITE_THREADSAFE" => threadsafe,
+    "NITRO_SQLITE_PERFORMANCE_MODE" => performance_mode,
     "NITRO_SQLITE_USE_PHONE_VERSION" => nil,
   )
   spec.attributes_hash.fetch("pod_target_xcconfig").fetch("OTHER_CFLAGS")
@@ -143,6 +168,14 @@ def assert_threadsafe(flags, expected)
 end
 
 def assert_optimization_flags(flags)
+  optimization_flags.each { |flag| assert_includes(flags, flag) }
+end
+
+def refute_optimization_flags(flags)
+  optimization_flags.each { |flag| refute_includes(flags, flag) }
+end
+
+def optimization_flags
   %w[
     -DSQLITE_DQS=0
     -DSQLITE_DEFAULT_MEMSTATUS=0
@@ -153,7 +186,7 @@ def assert_optimization_flags(flags)
     -DSQLITE_OMIT_PROGRESS_CALLBACK=1
     -DSQLITE_OMIT_SHARED_CACHE=1
     -DSQLITE_USE_ALLOCA=1
-  ].each { |flag| assert_includes(flags, flag) }
+  ]
 end
 
 def assert_invalid_package_value_rejected
@@ -181,6 +214,32 @@ def assert_invalid_environment_value_rejected
   fail "Expected an invalid NITRO_SQLITE_THREADSAFE value to fail"
 rescue RuntimeError => error
   expected = "NITRO_SQLITE_THREADSAFE must be true, false, 1, or 0"
+  fail "Unexpected validation error: #{error.message}" unless error.message == expected
+end
+
+def assert_invalid_package_performance_mode_rejected
+  with_app_package("nitroSQLite" => {"performanceMode" => 1}) do
+    evaluate_podspec(
+      "NITRO_SQLITE_THREADSAFE" => nil,
+      "NITRO_SQLITE_PERFORMANCE_MODE" => nil,
+    )
+  end
+  fail "Expected an invalid nitroSQLite.performanceMode value to fail"
+rescue RuntimeError => error
+  expected = "nitroSQLite.performanceMode in package.json must be true or false"
+  fail "Unexpected validation error: #{error.message}" unless error.message == expected
+end
+
+def assert_invalid_environment_performance_mode_rejected
+  with_app_package({}) do
+    evaluate_podspec(
+      "NITRO_SQLITE_THREADSAFE" => nil,
+      "NITRO_SQLITE_PERFORMANCE_MODE" => "enabled",
+    )
+  end
+  fail "Expected an invalid NITRO_SQLITE_PERFORMANCE_MODE value to fail"
+rescue RuntimeError => error
+  expected = "NITRO_SQLITE_PERFORMANCE_MODE must be true, false, 1, or 0"
   fail "Unexpected validation error: #{error.message}" unless error.message == expected
 end
 


### PR DESCRIPTION
NitroSQLite always enables its bundled SQLite optimization flags on iOS, and applications cannot opt out without editing the podspec. Thread safety should remain a separate choice because performance mode must never silently remove SQLite's mutex code. This PR adds an independent build-time performance setting to the consuming app's `package.json`.

Set `nitroSQLite.performanceMode` to `true` or `false`; it defaults to `true` to preserve current behavior. `NITRO_SQLITE_PERFORMANCE_MODE` accepts `true`, `false`, `1`, or `0` and overrides the package setting for a Pod installation. Disabling it omits NitroSQLite's optimization flags while leaving `nitroSQLite.threadSafe` unchanged.

This deliberately does not reuse the legacy numeric-string performance levels, which coupled performance flags to a `SQLITE_THREADSAFE` value. Thread safety is configured independently by the lower PR in this stack.

The podspec regression covers the default, both package values, environment overrides, invalid values, and precedence. It compiles and probes bundled SQLite with performance mode enabled and disabled.
