### PR TITLE
chore: configure TypeScript project references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,4 +89,5 @@ android/.gradle
 yalc.lock
 
 # Typescript
+**/.tsbuild/
 **/tsconfig.tsbuildinfo

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -1,17 +1,5 @@
 {
   "extends": "@tsconfig/react-native/tsconfig.json",
-  "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": [
-    "**/node_modules",
-    "**/Pods",
-    "**/lib",
-    "**/.eslintrc.js",
-    "**/.prettierrc.js",
-    "**/jest.config.js",
-    "**/babel.config.js",
-    "**/metro.config.js",
-    "**/tsconfig.json"
-  ],
   "compilerOptions": {
     "composite": true,
     "allowUnreachableCode": false,

--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -18,6 +18,8 @@ module.exports = {
           'stream': 'readable-stream',
           'buffer': 'react-native-quick-crypto',
           'react-native-sqlite-storage': 'react-native-nitro-sqlite',
+          '^@nitro-sqlite/(.+)':
+            '../packages/react-native-nitro-sqlite/src/\\1',
           '^@/(.+)': './src/\\1',
           '^@tests/(.+)': './tests/\\1',
         },

--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,7 @@
     "ios": "react-native run-ios",
     "bundle-install": "bundle install",
     "pods": "cd ios && bundle exec pod install",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --build",
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "codegen": "bun react-native codegen",
     "test:harness": "react-native-harness",

--- a/example/tests/db.ts
+++ b/example/tests/db.ts
@@ -7,7 +7,7 @@ import { open } from 'react-native-nitro-sqlite'
 import {
   getDatabaseQueue,
   type DatabaseQueue,
-} from '../../packages/react-native-nitro-sqlite/src/DatabaseQueue'
+} from '@nitro-sqlite/DatabaseQueue'
 
 const chance = new Chance()
 

--- a/example/tests/unit/specs/operations/execute.spec.ts
+++ b/example/tests/unit/specs/operations/execute.spec.ts
@@ -2,8 +2,8 @@ import { chance, expect, isNitroSQLiteError } from '@tests/unit/common'
 import { describe, it } from '@tests/TestApi'
 import { createArrayBufferTestDb, testDb } from '@tests/db'
 import { open } from 'react-native-nitro-sqlite'
-import { buildJSQueryResult } from '../../../../../packages/react-native-nitro-sqlite/src/operations/execute'
-import type { NitroSQLiteQueryResult } from '../../../../../packages/react-native-nitro-sqlite/src/specs/NitroSQLiteQueryResult.nitro'
+import { buildJSQueryResult } from '@nitro-sqlite/operations/execute'
+import type { NitroSQLiteQueryResult } from '@nitro-sqlite/specs/NitroSQLiteQueryResult.nitro'
 
 const QUERY_RESULT_SIZES = [60, 1_000, 10_000]
 

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,18 +1,13 @@
 {
   "extends": "../config/tsconfig.json",
-  "include": [
-    "src",
-    "tests",
-    "index.js",
-    "../packages/react-native-nitro-sqlite/src",
-    "rn-harness.config.mjs"
-  ],
+  "include": ["src", "tests", "index.js", "rn-harness.config.mjs"],
+  "references": [{ "path": "../packages/react-native-nitro-sqlite" }],
   "compilerOptions": {
     "paths": {
       "react-native-nitro-sqlite": [
-        "../packages/react-native-nitro-sqlite/src"
+        "../packages/react-native-nitro-sqlite/src/index.ts"
       ],
-      "*": ["./*"],
+      "@nitro-sqlite/*": ["../packages/react-native-nitro-sqlite/src/*"],
       "@/*": ["./src/*"],
       "@tests/*": ["./tests/*"]
     }

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   "homepage": "https://github.com/margelo/react-native-nitro-sqlite#readme",
   "scripts": {
     "postinstall": "patch-package",
-    "typecheck": "bun --filter=\"**\" typecheck",
+    "typecheck": "tsc --build",
     "lint": "bun sqlite lint && bun example lint",
     "lint-cpp": "./scripts/clang-format.sh",
     "prettier": "prettier --write .",
-    "clean": "rm -rf **/tsconfig.tsbuildinfo node_modules packages/react-native-nitro-sqlite/node_module packages/react-native-nitro-sqlite/lib",
+    "clean": "rm -rf **/.tsbuild **/tsconfig.tsbuildinfo node_modules packages/react-native-nitro-sqlite/node_module packages/react-native-nitro-sqlite/lib",
     "release": "./scripts/release.sh",
     "sqlite": "bun --cwd packages/react-native-nitro-sqlite",
     "example": "bun --cwd example"

--- a/packages/react-native-nitro-sqlite-vec/package.json
+++ b/packages/react-native-nitro-sqlite-vec/package.json
@@ -14,7 +14,7 @@
     "README.md"
   ],
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --build",
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "release": "release-it",
     "prepublishOnly": "bun typecheck"

--- a/packages/react-native-nitro-sqlite-vec/tsconfig.json
+++ b/packages/react-native-nitro-sqlite-vec/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "extends": "../../config/tsconfig.json",
-  "include": ["src", "../react-native-nitro-sqlite/src"],
+  "include": ["src"],
+  "references": [{ "path": "../react-native-nitro-sqlite" }],
   "compilerOptions": {
+    "rootDir": "src",
     "paths": {
-      "react-native-nitro-sqlite": ["../react-native-nitro-sqlite/src"]
+      "react-native-nitro-sqlite": ["../react-native-nitro-sqlite/src/index.ts"]
     }
   }
 }

--- a/packages/react-native-nitro-sqlite/tsconfig.json
+++ b/packages/react-native-nitro-sqlite/tsconfig.json
@@ -3,6 +3,9 @@
   "include": ["src"],
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib"
+    "outDir": ".tsbuild",
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "tsBuildInfoFile": ".tsbuild/tsconfig.tsbuildinfo"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./packages/react-native-nitro-sqlite" },
+    { "path": "./packages/react-native-nitro-sqlite-vec" },
+    { "path": "./example" }
+  ]
+}


### PR DESCRIPTION
The workspace previously typechecked each package independently and pulled sibling source trees into dependent TSConfig scopes. That blurred project boundaries and forced example tests to reach into the main package through fragile deep relative paths. This PR adds a root solution TSConfig, models package dependencies with project references, narrows every subproject to its own files, and introduces an `@nitro-sqlite/*` alias for internal example imports.

The core package emits declaration-only reference artifacts into an ignored `.tsbuild` directory, while the example and vec projects build their declared dependencies during standalone typechecks. The imports added by #320 now use the alias.