### PR TITLE
ci: fix native test workflow triggers

### DIFF
--- a/.github/workflows/test-harness-android.yml
+++ b/.github/workflows/test-harness-android.yml
@@ -1,6 +1,7 @@
 name: Test Harness Android
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - ".github/workflows/test-harness-android.yml"
@@ -9,8 +10,9 @@ on:
       - "example/tests/**"
       - "example/rn-harness.config.mjs"
       - "example/jest.config.js"
-      - "package/cpp/**"
-      - "package/android/**"
+      - "packages/react-native-nitro-sqlite/cpp/**"
+      - "packages/react-native-nitro-sqlite/android/**"
+      - "packages/react-native-nitro-sqlite-vec/cpp/**"
       - "**/bun.lock"
       - "**/react-native.config.js"
       - "**/nitro.json"

--- a/.github/workflows/test-harness-ios.yml
+++ b/.github/workflows/test-harness-ios.yml
@@ -1,6 +1,7 @@
 name: Test Harness iOS
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - ".github/workflows/test-harness-ios.yml"
@@ -9,8 +10,9 @@ on:
       - "example/tests/**"
       - "example/rn-harness.config.mjs"
       - "example/jest.config.js"
-      - "package/cpp/**"
-      - "package/ios/**"
+      - "packages/react-native-nitro-sqlite/cpp/**"
+      - "packages/react-native-nitro-sqlite/ios/**"
+      - "packages/react-native-nitro-sqlite-vec/cpp/**"
       - "**/Podfile.lock"
       - "**/*.podspec"
       - "**/react-native.config.js"


### PR DESCRIPTION
The iOS and Android harness workflows cannot be started manually, and their native path filters still point at the removed `package/` directory. Maintainers cannot run these jobs on demand, while changes under the current core or sqlite-vec native packages can miss automatic coverage. This extracts Samuel Scheit's workflow changes from #298, adds manual dispatch, and watches the native directories that exist in both packages.

Closes #343.
