### PR TITLE
fix(example): reset persisted benchmark schema

### DIFF
--- a/example/tests/db.ts
+++ b/example/tests/db.ts
@@ -55,20 +55,27 @@ const LARGE_DB_NAME = 'large'
 // Taken from "op-sqlite" example project.
 // Used to demonstrate the performance of NitroSQLite.
 const ROWS = 300000
+const LARGE_DB_SCHEMA: BatchQueryCommand[] = [
+  { query: 'DROP TABLE IF EXISTS Test;' },
+  {
+    query:
+      'CREATE TABLE Test ( id INT PRIMARY KEY, v1 TEXT, v2 TEXT, v3 TEXT, v4 TEXT, v5 TEXT, v6 INT, v7 INT, v8 INT, v9 INT, v10 INT, v11 REAL, v12 REAL, v13 REAL, v14 REAL) STRICT;',
+  },
+]
+
+export function resetLargeDbSchema(db: NitroSQLiteConnection) {
+  db.executeBatch(LARGE_DB_SCHEMA)
+}
+
 export let largeDb: NitroSQLiteConnection | undefined
 export function resetLargeDb() {
   try {
-    if (largeDb != null) {
-      largeDb.close()
-      largeDb.delete()
-    }
-    largeDb = open({
-      name: LARGE_DB_NAME,
-    })
+    largeDb ??= open({ name: LARGE_DB_NAME })
 
-    largeDb.execute(
-      'CREATE TABLE Test ( id INT PRIMARY KEY, v1 TEXT, v2 TEXT, v3 TEXT, v4 TEXT, v5 TEXT, v6 INT, v7 INT, v8 INT, v9 INT, v10 INT, v11 REAL, v12 REAL, v13 REAL, v14 REAL) STRICT;',
-    )
+    // The database file survives app restarts, while this module state does
+    // not. Rebuild the benchmark schema every time instead of assuming an
+    // absent connection means an absent table.
+    resetLargeDbSchema(largeDb)
 
     largeDb.execute('PRAGMA mmap_size=268435456')
 
@@ -99,6 +106,6 @@ export function resetLargeDb() {
 
     largeDb.executeBatch(insertions)
   } catch (e) {
-    console.warn('Error resetting user database', e)
+    console.warn('Error resetting large database', e)
   }
 }

--- a/example/tests/unit/index.ts
+++ b/example/tests/unit/index.ts
@@ -6,6 +6,7 @@ import registerExecuteBatchUnitTests from './specs/operations/executeBatch.spec'
 import registerTypeORMUnitTestsSpecs from './specs/typeorm.spec'
 import registerDatabaseQueueUnitTests from './specs/DatabaseQueue.spec'
 import registerSqliteVecUnitTestsSpecs from './specs/sqlite-vec.spec'
+import registerBenchmarkDatabaseUnitTests from './specs/benchmarkDatabase.spec'
 
 export function registerUnitTests() {
   beforeEach(setupTestDb)
@@ -14,6 +15,7 @@ export function registerUnitTests() {
     registerExecuteUnitTests()
     registerTransactionUnitTests()
     registerExecuteBatchUnitTests()
+    registerBenchmarkDatabaseUnitTests()
   })
 
   registerDatabaseQueueUnitTests()

--- a/example/tests/unit/specs/benchmarkDatabase.spec.ts
+++ b/example/tests/unit/specs/benchmarkDatabase.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it } from '@tests/TestApi'
+import { expect } from '@tests/unit/common'
+import { resetLargeDbSchema } from '@tests/db'
+import { open } from 'react-native-nitro-sqlite'
+
+const DB_NAME = 'benchmark_schema_reset'
+
+export default function registerBenchmarkDatabaseUnitTests() {
+  describe('benchmark database', () => {
+    it('rebuilds an existing benchmark table', () => {
+      const db = open({ name: DB_NAME })
+
+      try {
+        db.execute('DROP TABLE IF EXISTS Test;')
+        db.execute('CREATE TABLE Test (legacy TEXT);')
+
+        resetLargeDbSchema(db)
+
+        const columns = db.execute('PRAGMA table_info(Test);')
+        expect(columns.rows?._array.map((column) => column.name)).toEqual([
+          'id',
+          'v1',
+          'v2',
+          'v3',
+          'v4',
+          'v5',
+          'v6',
+          'v7',
+          'v8',
+          'v9',
+          'v10',
+          'v11',
+          'v12',
+          'v13',
+          'v14',
+        ])
+      } finally {
+        db.close()
+        db.delete()
+      }
+    })
+  })
+}


### PR DESCRIPTION
The benchmark database file persists across app restarts, but its module-scoped connection state does not. A fresh runtime can therefore reopen the existing `Test` table and fail before the benchmark starts. This extracts Samuel Scheit's fix from #298 by rebuilding the expected schema transactionally before inserting benchmark data. A native regression test starts with an incompatible table and checks that the reset restores every benchmark column.

## Reproduction

1. Run the large database benchmark once so the app creates its on-disk database.
2. Restart the app without deleting that database.
3. Run the benchmark again.

Before this change, the second run can fail because `Test` already exists. After this change, the reset replaces the persisted table before inserting benchmark rows.

Closes #345.
