### PR TITLE
fix: export source entry for React Native

### DIFF
--- a/packages/react-native-nitro-sqlite/package.json
+++ b/packages/react-native-nitro-sqlite/package.json
@@ -9,6 +9,7 @@
   "react-native": "./src/index",
   "exports": {
     ".": {
+      "react-native": "./src/index.ts",
       "import": {
         "types": "./lib/typescript/module/index.d.ts",
         "default": "./lib/module/index.js"


### PR DESCRIPTION
React Native consumers can resolve `react-native-nitro-sqlite` through the package `exports` map, but that map currently exposes only the built ESM and CommonJS entry points. Metro therefore cannot select the package source when it resolves the package through conditional exports. This PR extracts the React Native source condition from #298 so the package fix can be reviewed independently of macOS support.

The new condition points to `src/index.ts`, which is already included in the published `files` list. Metro selects that source entry for both iOS and Android, while ordinary ESM imports and CommonJS requires retain their existing built targets. No example-wide Metro alias is needed for installed-package resolution.

Originally authored by @samuelscheit in #298.

Closes #344.
