### PR TITLE
fix: align native namespaces with Nitro

### DIFF
--- a/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.cpp
+++ b/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.cpp
@@ -1,11 +1,11 @@
 #include "HybridNitroSQLite.hpp"
 #include "HybridNitroSQLiteQueryResult.hpp"
-#include "NitroSQLiteException.hpp"
-#include "importSqlFile.hpp"
-#include "logs.hpp"
-#include "macros.hpp"
-#include "operations.hpp"
-#include "sqliteExecuteBatch.hpp"
+#include "../NitroSQLiteException.hpp"
+#include "../importSqlFile.hpp"
+#include "../logs.hpp"
+#include "../macros.hpp"
+#include "../operations.hpp"
+#include "../sqliteExecuteBatch.hpp"
 #include <exception>
 #include <iostream>
 #include <map>

--- a/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.cpp
+++ b/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.cpp
@@ -1,11 +1,11 @@
 #include "HybridNitroSQLite.hpp"
-#include "HybridNitroSQLiteQueryResult.hpp"
 #include "../NitroSQLiteException.hpp"
 #include "../importSqlFile.hpp"
 #include "../logs.hpp"
 #include "../macros.hpp"
 #include "../operations.hpp"
 #include "../sqliteExecuteBatch.hpp"
+#include "HybridNitroSQLiteQueryResult.hpp"
 #include <exception>
 #include <iostream>
 #include <map>

--- a/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.hpp
+++ b/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.hpp
@@ -2,9 +2,7 @@
 
 #include "HybridNitroSQLiteQueryResultSpec.hpp"
 #include "HybridNitroSQLiteSpec.hpp"
-#include "types.hpp"
-
-using namespace margelo::rnnitrosqlite;
+#include "../types.hpp"
 
 namespace margelo::nitro::rnnitrosqlite {
 

--- a/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.hpp
+++ b/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLite.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "../types.hpp"
 #include "HybridNitroSQLiteQueryResultSpec.hpp"
 #include "HybridNitroSQLiteSpec.hpp"
-#include "../types.hpp"
 
 namespace margelo::nitro::rnnitrosqlite {
 

--- a/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLiteQueryResult.hpp
+++ b/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLiteQueryResult.hpp
@@ -1,10 +1,8 @@
 #pragma once
 
 #include "HybridNitroSQLiteQueryResultSpec.hpp"
-#include "types.hpp"
+#include "../types.hpp"
 #include <map>
-
-using namespace margelo::rnnitrosqlite;
 
 namespace margelo::nitro::rnnitrosqlite {
 

--- a/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLiteQueryResult.hpp
+++ b/packages/react-native-nitro-sqlite/cpp/hybridObjects/HybridNitroSQLiteQueryResult.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "HybridNitroSQLiteQueryResultSpec.hpp"
 #include "../types.hpp"
+#include "HybridNitroSQLiteQueryResultSpec.hpp"
 #include <map>
 
 namespace margelo::nitro::rnnitrosqlite {

--- a/packages/react-native-nitro-sqlite/cpp/importSqlFile.cpp
+++ b/packages/react-native-nitro-sqlite/cpp/importSqlFile.cpp
@@ -8,7 +8,7 @@
 #include <fstream>
 #include <iostream>
 
-namespace margelo::rnnitrosqlite {
+namespace margelo::nitro::rnnitrosqlite {
 
 SQLiteOperationResult importSqlFile(const std::string& dbName, const std::string& fileLocation) {
   return importSqlFile(sqliteGetOpenDatabase(dbName), fileLocation);
@@ -50,4 +50,4 @@ SQLiteOperationResult importSqlFile(const SQLiteConnectionPtr& connection, const
   }
 }
 
-} // namespace margelo::rnnitrosqlite
+} // namespace margelo::nitro::rnnitrosqlite

--- a/packages/react-native-nitro-sqlite/cpp/importSqlFile.hpp
+++ b/packages/react-native-nitro-sqlite/cpp/importSqlFile.hpp
@@ -9,11 +9,11 @@
 #include "types.hpp"
 #include <memory>
 
-namespace margelo::rnnitrosqlite {
+namespace margelo::nitro::rnnitrosqlite {
 
 struct SQLiteConnection;
 
 SQLiteOperationResult importSqlFile(const std::string& dbName, const std::string& fileLocation);
 SQLiteOperationResult importSqlFile(const std::shared_ptr<SQLiteConnection>& connection, const std::string& fileLocation);
 
-} // namespace margelo::rnnitrosqlite
+} // namespace margelo::nitro::rnnitrosqlite

--- a/packages/react-native-nitro-sqlite/cpp/operations.cpp
+++ b/packages/react-native-nitro-sqlite/cpp/operations.cpp
@@ -22,10 +22,8 @@
 #endif
 
 using namespace facebook;
-using namespace margelo::nitro;
-using namespace margelo::nitro::rnnitrosqlite;
 
-namespace margelo::rnnitrosqlite {
+namespace margelo::nitro::rnnitrosqlite {
 
 static constexpr double kInt64MinAsDouble = static_cast<double>(std::numeric_limits<int64_t>::min());
 static constexpr double kInt64UpperBoundAsDouble = -kInt64MinAsDouble;
@@ -355,4 +353,4 @@ SQLiteOperationResult sqliteExecuteCommand(const SQLiteConnectionPtr& connection
   return {.rowsAffected = isReadOnly ? 0 : sqlite3_changes(db)};
 }
 
-} // namespace margelo::rnnitrosqlite
+} // namespace margelo::nitro::rnnitrosqlite

--- a/packages/react-native-nitro-sqlite/cpp/operations.hpp
+++ b/packages/react-native-nitro-sqlite/cpp/operations.hpp
@@ -7,7 +7,7 @@
 #include <sqlite3.h>
 #include <string>
 
-namespace margelo::rnnitrosqlite {
+namespace margelo::nitro::rnnitrosqlite {
 
 // Calls against one connection are serialized by `mutex`. Separate connections
 // intentionally remain independent, so SQLITE_THREADSAFE=0 still requires the
@@ -53,4 +53,4 @@ SQLiteOperationResult sqliteExecuteCommand(const SQLiteConnectionPtr& connection
 
 void sqliteCloseAll();
 
-} // namespace margelo::rnnitrosqlite
+} // namespace margelo::nitro::rnnitrosqlite

--- a/packages/react-native-nitro-sqlite/cpp/sqliteExecuteBatch.cpp
+++ b/packages/react-native-nitro-sqlite/cpp/sqliteExecuteBatch.cpp
@@ -6,7 +6,7 @@
 #include "operations.hpp"
 #include <utility>
 
-namespace margelo::rnnitrosqlite {
+namespace margelo::nitro::rnnitrosqlite {
 
 std::vector<BatchQuery> batchParamsToCommands(const std::vector<BatchQueryCommand>& batchParams) {
   auto commands = std::vector<BatchQuery>();
@@ -67,4 +67,4 @@ SQLiteOperationResult sqliteExecuteBatch(const SQLiteConnectionPtr& connection, 
   }
 }
 
-} // namespace margelo::rnnitrosqlite
+} // namespace margelo::nitro::rnnitrosqlite

--- a/packages/react-native-nitro-sqlite/cpp/sqliteExecuteBatch.hpp
+++ b/packages/react-native-nitro-sqlite/cpp/sqliteExecuteBatch.hpp
@@ -7,10 +7,7 @@
 #include "types.hpp"
 #include <memory>
 
-using namespace facebook;
-using namespace margelo::nitro;
-
-namespace margelo::rnnitrosqlite {
+namespace margelo::nitro::rnnitrosqlite {
 
 struct SQLiteConnection;
 
@@ -31,4 +28,4 @@ std::vector<BatchQuery> batchParamsToCommands(const std::vector<BatchQueryComman
 SQLiteOperationResult sqliteExecuteBatch(const std::string& dbName, const std::vector<BatchQuery>& commands);
 SQLiteOperationResult sqliteExecuteBatch(const std::shared_ptr<SQLiteConnection>& connection, const std::vector<BatchQuery>& commands);
 
-} // namespace margelo::rnnitrosqlite
+} // namespace margelo::nitro::rnnitrosqlite

--- a/packages/react-native-nitro-sqlite/cpp/types.hpp
+++ b/packages/react-native-nitro-sqlite/cpp/types.hpp
@@ -5,12 +5,9 @@
 #include <NitroModules/ArrayBuffer.hpp>
 #include <string>
 
-using namespace margelo::nitro;
-using namespace margelo::nitro::rnnitrosqlite;
+namespace margelo::nitro::rnnitrosqlite {
 
-namespace margelo::rnnitrosqlite {
-
-using SQLiteValue = std::variant<nitro::NullType, bool, std::shared_ptr<ArrayBuffer>, std::string, double>;
+using SQLiteValue = std::variant<NullType, bool, std::shared_ptr<ArrayBuffer>, std::string, double>;
 using SQLiteQueryParams = std::vector<SQLiteValue>;
 using SQLiteQueryResultRow = std::unordered_map<std::string, SQLiteValue>;
 using SQLiteQueryResults = std::vector<SQLiteQueryResultRow>;
@@ -40,4 +37,4 @@ inline ColumnType mapSQLiteTypeToColumnType(const char* type) {
   }
 }
 
-} // namespace margelo::rnnitrosqlite
+} // namespace margelo::nitro::rnnitrosqlite

--- a/packages/react-native-nitro-sqlite/cpp/utils.hpp
+++ b/packages/react-native-nitro-sqlite/cpp/utils.hpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <sys/stat.h>
 
-namespace margelo::rnnitrosqlite {
+namespace margelo::nitro::rnnitrosqlite {
 
 bool folder_exists(const std::string& foldername) {
   struct stat buffer;
@@ -57,4 +57,4 @@ std::string get_db_path(const std::string& dbName, const std::string& docPath) {
   return docPath + "/" + dbName;
 }
 
-} // namespace margelo::rnnitrosqlite
+} // namespace margelo::nitro::rnnitrosqlite


### PR DESCRIPTION
Handwritten SQLite helpers use `margelo::rnnitrosqlite`, while Nitrogen puts generated specs and types in `margelo::nitro::rnnitrosqlite`. Hybrid-object sources also depend on broad header search paths to find headers from the parent C++ directory. This PR aligns the handwritten code with the generated namespace and makes those parent-directory includes explicit. It removes the now-unused broad namespace directives without changing query serialization, ArrayBuffer copying, or declared-type comparison behavior.

Extracted from #298.

Fixes #349

Related #332
